### PR TITLE
cleanup.py has ValueError: 0.0 is not valid SemVer string

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Dependencies
 Installing
 ----------
 - **debian** / **ubuntu**:
-  `apt-get install python3-yaml python3-requests python3-click python3-distro python3-psutil python3-pexpect`
+  `apt-get install python3-click, python3 -m pip install psutil, python3 -m pip install distro, python3 -m pip install pexpect, sudo python3 -m pip install pyyaml, sudo python3 -m pip install lib`
 - **centos**:
    `yum update ; yum install python3 python3-pyyaml python36-PyYAML python3-requests python3-click gcc platform-python-devel python3-distro python3-devel python36-distro python36-click python36-pexpect python3-pexpect; pip3 install psutil `
 - **plain pip**:
@@ -51,7 +51,7 @@ Supported Parameters:
  
 Example usage:
  - Windows: `python ./release_tester/test.py --version 3.6.2 --enterprise True --package-dir c:/Users/willi/Downloads `
- - Linux (ubuntu|debian) `python3 ./release_tester/test.py --version 3.6.2 --enterprise True --package-dir /home/willi/Downloads`
+ - Linux (ubuntu|debian) `python3 ./release_tester/test.py --version 3.6.2 --enterprise --package-dir /home/willi/Downloads`
  - Linux (centos|fedora|sles) `python3 ./release_tester/test.py --version 3.6.2 --enterprise True --package-dir /home/willi/Downloads`
 
 Using upgrade.py for upgrade testing

--- a/release_tester/cleanup.py
+++ b/release_tester/cleanup.py
@@ -25,7 +25,7 @@ def run_test():
     """ main """
     logging.getLogger().setLevel(logging.DEBUG)
 
-    inst = installers.get('0.0',
+    inst = installers.get('3.3.3',
                           True,
                           False,
                           Path("/tmp/"),


### PR DESCRIPTION
When I tried to run ./cleanup.py it gave me this error: 0.0 is not valid SemVer string

**Console log:**
`root@fattah-VirtualBox:/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester# python3 ./cleanup.py Traceback (most recent call last): File "./cleanup.py", line 49, in <module> run_test() File "./cleanup.py", line 28, in run_test inst = make_installer(install_config) File "/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester/arangodb/installers/__init__.py", line 78, in make_installer return InstallerDeb(install_config) File "/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester/arangodb/installers/deb.py", line 29, in __init__ self.semver = semver.VersionInfo.parse(version) File "/usr/local/lib/python3.8/dist-packages/semver.py", line 656, in parse raise ValueError("%s is not valid SemVer string" % version) ValueError: 0.0 is not valid SemVer string root@fattah-VirtualBox:/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester#`

**Fix:** This issue can be fixed by putting any valid number in cleanup.py Line: 22. Instead of 0.0, this error is gone after putting value 3.3.3.