### PR TITLE
Update cleanup.py

### DIFF
--- a/release_tester/cleanup.py
+++ b/release_tester/cleanup.py
@@ -19,7 +19,7 @@ def run_test():
     """ main """
     logging.getLogger().setLevel(logging.DEBUG)
 
-    install_config = InstallerConfig('0.0',
+    install_config = InstallerConfig('3.3.3',
                                      True,
                                      False,
                                      Path("/tmp/"),


### PR DESCRIPTION
When I tried to run ./cleanup.py it gave me this error: 0.0 is not valid SemVer string.

**Console log:**
`root@fattah-VirtualBox:/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester# python3 ./cleanup.py Traceback (most recent call last): File "./cleanup.py", line 49, in <module> run_test() File "./cleanup.py", line 28, in run_test inst = make_installer(install_config) File "/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester/arangodb/installers/__init__.py", line 78, in make_installer return InstallerDeb(install_config) File "/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester/arangodb/installers/deb.py", line 29, in __init__ self.semver = semver.VersionInfo.parse(version) File "/usr/local/lib/python3.8/dist-packages/semver.py", line 656, in parse raise ValueError("%s is not valid SemVer string" % version) ValueError: 0.0 is not valid SemVer string root@fattah-VirtualBox:/home/fattah/Downloads/Ubuntu/release-test-automation-master/release_tester#`

**Fix:** This issue can be fixed by putting any valid number in cleanup.py Line: 22. Instead of 0.0, this error is gone after putting value 3.3.3.