### PR TITLE
Update deb.py

### DIFF
--- a/release_tester/arangodb/installers/deb.py
+++ b/release_tester/arangodb/installers/deb.py
@@ -101,6 +101,17 @@ class InstallerDeb(InstallerBase):
             logging.info("X" * 80)
             logging.info("Upgrade failed!")
             sys.exit(1)
+
+        try:
+            server_upgrade.expect('Database files are up-to-date')
+            ascii_print(server_upgrade.before)
+        except pexpect.exceptions.EOF:
+            logging.info("X" * 80)
+            ascii_print(server_upgrade.before)
+            logging.info("X" * 80)
+            logging.info("Already up-to-date.")
+            sys.exit(1)
+
         try:
             logging.info("waiting for the upgrade to finish")
             server_upgrade.expect(pexpect.EOF, timeout=30)


### PR DESCRIPTION
**Issue:**
upgrade process gets failed when tried to upgrade from version 3.6.3.1 --> 3.6.4 which most probably database is already up to date and upgrade is not needed.

**Log (from the console):**

############################################################
############################################################
#                    install new: 3.6.4                    #
############################################################
############################################################
14:03:55 INFO deb.py:83 - upgrading Arangodb debian package
14:04:09 INFO deb.py:91 - XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
(Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 222846 files and directories currently installed.)
Preparing to unpack .../arangodb3e_3.6.4-1_amd64.deb ...
Unpacking arangodb3e (3.6.4-1) over (3.6.3.1-1) ...
Setting up arangodb3e (3.6.4-1) ...
Database files are up-to-date.
Processing triggers for ureadahead (0.100.0-19.1) ...
Processing triggers for systemd (229-4ubuntu21.28) ...
Processing triggers for man-db (2.7.5-1) ...
14:04:09 INFO deb.py:93 - XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
14:04:09 INFO deb.py:94 - Upgrade failed!

**Solution:**  are given below.