### PR TITLE
add the case that there may be a ready existing arangod.conf, and dpkg asks what to do with it

### DIFF
--- a/release_tester/arangodb/installers/deb.py
+++ b/release_tester/arangodb/installers/deb.py
@@ -127,7 +127,11 @@ class InstallerDeb(InstallerBase):
         server_install = pexpect.spawnu(cmd)
         try:
             logging.debug("expect: user1")
-            server_install.expect('user:')
+            i = server_install.expect(['user:', 'arangod.conf'])
+            if i == 1: # there are remaints of previous installations. We overwrite existing config files.
+                server_install.sendline('Y')
+                ascii_print(server_install.before)
+                server_install.expect('user:')
             ascii_print(server_install.before)
             logging.debug("expect: setting password: {0.cfg.passvoid}".format(self))
             server_install.sendline(self.cfg.passvoid)


### PR DESCRIPTION
If there is already a config there, the install-flow looks like that:
```
/usr/bin/dpkg -i /home/willi/Downloads/arangodb3e_3.7.1~rc.1-1_amd64.deb
(Reading database ... 323454 files and directories currently installed.)
Preparing to unpack .../arangodb3e_3.7.1~rc.1-1_amd64.deb ...
Unpacking arangodb3e (3.7.1~rc.1-1) over (3.7.1~rc.1-1) ...
Setting up arangodb3e (3.7.1~rc.1-1) ...

Configuration file '/etc/arangodb3/arangosh.conf'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** arangosh.conf (Y/I/N/O/D/Z) [default=N] ? y
Installing new version of config file /etc/arangodb3/arangosh.conf ...
```