### PR TITLE
implement nightly tarball tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,9 +335,35 @@ Running the docker container, parametrizing the connection endpoints of the clus
 docker run test:latest --frontends tcp://192.168.173.88:9629 --frontends tcp://192.168.173.88:9729 --frontends tcp://192.168.173.88:9529 --scenario scenarios/cluster_replicated.yml
 ```
 
+# nightly tar docker container
+This container is intended to test the nightly tar packages whether starter deployment upgrades are working properly.
 
+Build the container for later use with:
+```
+docker build docker_tar/ -t docker_tar
+```
+
+Run the container from within the office network:
+```
+docker run --env PYTHONPATH=/home/release-test-automation/release_tester \
+  -v `pwd`:/home/release-test-automation \
+  -v /home/willi/Downloads/:/home/package_cache \
+  -v /tmp/versions:/home/versions \
+  docker_tar 3.7.7-nightly 3.8.0-nightly ftp:stage2
+```
+
+Run the container from abroad:
+```
+docker run --env PYTHONPATH=/home/release-test-automation/release_tester \
+  -v `pwd`:/home/release-test-automation \
+  -v /home/willi/Downloads/:/home/package_cache \
+  -v /tmp/versions:/home/versions \
+  docker_tar 3.7.7-nightly 3.8.0-nightly http:stage2 user passvoid
+```
 
 ## Wikipedia dump tests
 These tests use the CSV data from the wikip
  http://home.apache.org/~mikemccand/enwiki-20120502-lines-1k.txt.lzma
+
+
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ docker run --env PYTHONPATH=/home/release-test-automation/release_tester \
   -v `pwd`:/home/release-test-automation \
   -v /home/willi/Downloads/:/home/package_cache \
   -v /tmp/versions:/home/versions \
-  docker_tar 3.7.7-nightly 3.8.0-nightly http:stage2 user passvoid
+  docker_tar --old-version 3.7.7-nightly --new-version 3.8.0-nightly --source http:stage2 --httpuser user --httppassvoid passvoid
 ```
 
 ## Wikipedia dump tests

--- a/docker_tar/Dockerfile
+++ b/docker_tar/Dockerfile
@@ -8,5 +8,6 @@ RUN apt-get update ; \
     rm -rf /var/lib/apt/lists/*
     
 RUN pip3 install semver
-
-# ENTRYPOINT ["/entrypoint.sh"]
+RUN mkdir -p /home/entrypoint /home/release-test-automation /home/package_cache /home/versions
+ADD tarball_nightly_test.py /home/entrypoint/tarball_nightly_test.py
+ENTRYPOINT ["/home/entrypoint/tarball_nightly_test.py"]

--- a/docker_tar/tarball_nightly_test.py
+++ b/docker_tar/tarball_nightly_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+from pathlib import Path
+
+import sys
+from acquire_packages import acquire_package
+from upgrade import run_upgrade
+verbose = True
+old_version = sys.argv[1] # "3.7.7-nightly"
+new_version = sys.argv[2] # "3.8.0-nightly"
+download_dir = "/home/package_cache"
+test_data_dir = "/home/test_dir"
+version_state_dir = Path("/home/versions")
+epmagic = '' # not needed for stage 1/2
+dlstage = "ftp:stage2"
+username = ""
+passvoid = ""
+if len(sys.argv) > 3:
+    username = sys.argv[3]
+    passvoid = sys.argv[4]
+
+zip = True
+
+old_version_state = None
+new_version_state = None
+
+old_version_content = None
+new_version_content = None
+
+for enterprise in [True, False]:
+    
+    dl_old = acquire_package(old_version, verbose, download_dir, enterprise, epmagic, zip, username, passvoid);
+    dl_new = acquire_package(new_version, verbose, download_dir, enterprise, epmagic, zip, username, passvoid);
+    
+    old_version_state = version_state_dir / Path(dl_old.cfg.version + "_sourceInfo.log")
+    new_version_state = version_state_dir / Path(dl_new.cfg.version + "_sourceInfo.log")
+    if old_version_state.exists():
+        old_version_content = old_version_state.read_text()
+    if new_version_state.exists():
+        new_version_content = new_version_state.read_text()
+    
+    fresh_old_content = dl_old.get_version_info(dlstage)
+    fresh_new_content = dl_new.get_version_info(dlstage)
+    
+    if old_version_content == fresh_old_content and new_version_content == fresh_new_content:
+        print("we already tested this version. bye.")
+        exit(0)
+              
+    dl_old.get_packages(True, dlstage)
+    dl_new.get_packages(True, dlstage)
+    
+    print("santeuh")
+    
+    run_upgrade(dl_old.cfg.version,
+                dl_new.cfg.version,
+                verbose,
+                download_dir, test_data_dir,
+                enterprise, zip, False,
+                "all", False, "127.0.0.1")
+
+old_version_state.write_text(fresh_old_content)
+new_version_state.write_text(fresh_new_content)

--- a/docker_tar/tarball_nightly_test.py
+++ b/docker_tar/tarball_nightly_test.py
@@ -2,58 +2,81 @@
 from pathlib import Path
 
 import sys
+import click
 from acquire_packages import acquire_package
 from upgrade import run_upgrade
-verbose = True
-old_version = sys.argv[1] # "3.7.7-nightly"
-new_version = sys.argv[2] # "3.8.0-nightly"
-download_dir = "/home/package_cache"
-test_data_dir = "/home/test_dir"
-version_state_dir = Path("/home/versions")
-epmagic = '' # not needed for stage 1/2
-dlstage = "ftp:stage2"
-username = ""
-passvoid = ""
-if len(sys.argv) > 3:
-    dlstage = sys.argv[3]
-    username = sys.argv[4]
-    passvoid = sys.argv[5]
 
-zip = True
+def upgrade_package_test(verbose, new_version, old_version, package_dir, enterprise_magic, zip, dlstage, httpusername, httppassvoid, test_data_dir, version_state_dir):
+    old_version_state = None
+    new_version_state = None
+    old_version_content = None
+    new_version_content = None
 
-old_version_state = None
-new_version_state = None
+    for enterprise in [True, False]:
+        dl_old = acquire_package(old_version, verbose, package_dir, enterprise, enterprise_magic, zip, httpusername, httppassvoid);
+        dl_new = acquire_package(new_version, verbose, package_dir, enterprise, enterprise_magic, zip, httpusername, httppassvoid);
+        old_version_state = version_state_dir / Path(dl_old.cfg.version + "_sourceInfo.log")
+        new_version_state = version_state_dir / Path(dl_new.cfg.version + "_sourceInfo.log")
+        if old_version_state.exists():
+            old_version_content = old_version_state.read_text()
+        if new_version_state.exists():
+            new_version_content = new_version_state.read_text()
 
-old_version_content = None
-new_version_content = None
+        fresh_old_content = dl_old.get_version_info(dlstage)
+        fresh_new_content = dl_new.get_version_info(dlstage)
 
-for enterprise in [True, False]:
-    
-    dl_old = acquire_package(old_version, verbose, download_dir, enterprise, epmagic, zip, username, passvoid);
-    dl_new = acquire_package(new_version, verbose, download_dir, enterprise, epmagic, zip, username, passvoid);
-    
-    old_version_state = version_state_dir / Path(dl_old.cfg.version + "_sourceInfo.log")
-    new_version_state = version_state_dir / Path(dl_new.cfg.version + "_sourceInfo.log")
-    if old_version_state.exists():
-        old_version_content = old_version_state.read_text()
-    if new_version_state.exists():
-        new_version_content = new_version_state.read_text()
-    
-    fresh_old_content = dl_old.get_version_info(dlstage)
-    fresh_new_content = dl_new.get_version_info(dlstage)
-    
-    if old_version_content == fresh_old_content and new_version_content == fresh_new_content:
-        print("we already tested this version. bye.")
-        exit(0)
-              
-    dl_old.get_packages(True, dlstage)
-    dl_new.get_packages(True, dlstage)
-    run_upgrade(dl_old.cfg.version,
-                dl_new.cfg.version,
-                verbose,
-                download_dir, test_data_dir,
-                enterprise, zip, False,
-                "all", False, "127.0.0.1")
+        if old_version_content == fresh_old_content and new_version_content == fresh_new_content:
+            print("we already tested this version. bye.")
+            exit(0)
 
-old_version_state.write_text(fresh_old_content)
-new_version_state.write_text(fresh_new_content)
+        dl_old.get_packages(True, dlstage)
+        dl_new.get_packages(True, dlstage)
+        run_upgrade(dl_old.cfg.version,
+                    dl_new.cfg.version,
+                    verbose,
+                    package_dir, test_data_dir,
+                    enterprise, zip, False,
+                    "all", False, "127.0.0.1")
+
+
+    old_version_state.write_text(fresh_old_content)
+    new_version_state.write_text(fresh_new_content)
+    return 0
+
+@click.command()
+@click.option('--verbose/--no-verbose',
+              is_flag=True,
+              default=True,
+              help='switch starter to verbose logging mode.')
+@click.option('--new-version', help='ArangoDB version number.', default="3.8.0-nightly")
+@click.option('--old-version', help='old ArangoDB version number.', default="3.7.7-nightly")
+@click.option('--enterprise-magic',
+              default='',
+              help='Enterprise or community?')
+@click.option('--zip/--no-zip',
+              is_flag=True,
+              default=True,
+              help='switch to zip or tar.gz package instead of default OS package')
+@click.option('--package-dir',
+              default='/home/package_cache/',
+              help='directory to store the packages to.')
+@click.option('--source',
+              default='ftp:stage2',
+              help='where to download the package from [[ftp|http]:stage1|[ftp|http]:stage2|public]')
+@click.option('--httpuser',
+              default="",
+              help='user for external http download')
+@click.option('--httppassvoid',
+              default="",
+              help='passvoid for external http download')
+@click.option('--test-data-dir',
+              default='/home/test_dir',
+              help='directory create databases etc. in.')
+@click.option('--version-state-dir',
+              default='/home/versions',
+              help='directory to remember the tested version combination in.')
+def main(verbose, new_version, old_version, package_dir, enterprise_magic, zip, source, httpuser, httppassvoid, test_data_dir, version_state_dir):
+    return upgrade_package_test(verbose, new_version, old_version, package_dir, enterprise_magic, zip, source, httpuser, httppassvoid, test_data_dir, version_state_dir)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docker_tar/tarball_nightly_test.py
+++ b/docker_tar/tarball_nightly_test.py
@@ -15,8 +15,9 @@ dlstage = "ftp:stage2"
 username = ""
 passvoid = ""
 if len(sys.argv) > 3:
-    username = sys.argv[3]
-    passvoid = sys.argv[4]
+    dlstage = sys.argv[3]
+    username = sys.argv[4]
+    passvoid = sys.argv[5]
 
 zip = True
 

--- a/docker_tar/tarball_nightly_test.py
+++ b/docker_tar/tarball_nightly_test.py
@@ -48,9 +48,6 @@ for enterprise in [True, False]:
               
     dl_old.get_packages(True, dlstage)
     dl_new.get_packages(True, dlstage)
-    
-    print("santeuh")
-    
     run_upgrade(dl_old.cfg.version,
                 dl_new.cfg.version,
                 verbose,

--- a/release_tester/acquire_packages.py
+++ b/release_tester/acquire_packages.py
@@ -8,6 +8,7 @@ import sys
 import click
 from arangodb.installers import make_installer, InstallerConfig
 import tools.loghelper as lh
+import semver
 
 import requests
 
@@ -17,100 +18,185 @@ logging.basicConfig(
     format='%(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s'
 )
 
-passvoid = ''
-user = ''
 
-def acquire_stage_ftp(directory, package, local_dir, force, stage):
-    out = local_dir / package
-    if out.exists() and not force:
-        print(stage + ": not overwriting {file} since not forced to overwrite!".format(**{
-            "file": str(out)
-        }))
-        return
-    ftp = FTP('Nas02.arangodb.biz')
-    print(stage + ": " + ftp.login(user='anonymous', passwd='anonymous', acct='anonymous'))
-    print(stage + ": " + ftp.cwd(directory))
-    ftp.set_pasv(True)
-    with out.open(mode='wb') as fd:
-        print(stage + ": downloading to " + str(out))
-        print(stage + ": " + ftp.retrbinary('RETR ' + package, fd.write))
 
-def acquire_stage_http(directory, package, local_dir, force, stage):
-    global passvoid, user
-    #url = 'https://{user}:{passvoid}@Nas02.arangodb.biz/{dir}{pkg}'.format(**{
-    #    'passvoid': passvoid,
-    #    'user': user,
-    #    'dir': directory,
-    #    'pkg': package
-    #    })
+class acquire_package():
+    def __init__(self,
+                 version,
+                 verbose,
+                 package_dir,
+                 enterprise,
+                 enterprise_magic,
+                 zip,
+                 httpuser,
+                 httppassvoid):
+        global passvoid, user
+        """ main """
+        lh.section("configuration")
+        print("version: " + str(version))
+        print("using enterpise: " + str(enterprise))
+        print("using zip: " + str(zip))
+        print("package directory: " + str(package_dir))
+        print("verbose: " + str(verbose))
+        self.user = httpuser
+        self.passvoid = httppassvoid
+    
+        lh.section("startup")
+        if verbose:
+            logging.info("setting debug level to debug (verbose)")
+            logging.getLogger().setLevel(logging.DEBUG)
 
-    url = 'https://{user}:{passvoid}@fileserver.arangodb.com:8529/{dir}{pkg}'.format(**{
-        'passvoid': passvoid,
-        'user': user,
-        'dir': directory,
-        'pkg': package
-        })
 
-    out = local_dir / package
-    if out.exists() and not force:
-        print(stage + ": not overwriting {file} since not forced to overwrite!".format(**{
-            "file": str(out)
-        }))
-        return
-    print(stage + ": downloading " + str(url))
-    res = requests.get(url)
-    if res.status_code == 200:
-        print(stage + ": writing {size} kbytes to {file}".format(**{
-            "size": str(len(res.content) / 1024),
-            "file": str(out)
-        }))
-        out.write_bytes(res.content)
-    else:
-        raise Exception(stage + ": failed to download {url} - {error} - {msg}".format(**{
-            "url": url,
-            "error": res.status_code,
-            "msg": res.text
+        self.package_dir = Path(package_dir)
+        self.cfg = InstallerConfig(version,
+                                   verbose,
+                                   enterprise,
+                                   zip,
+                                   self.package_dir,
+                                   Path("/"),
+                                   "",
+                                   "127.0.0.1",
+                                   False,
+                                   False)
+        self.inst = make_installer(self.cfg)
+
+        is_nightly = self.inst.semver.prerelease == "nightly"
+        self.params = {
+            "full_version": 'v{major}.{minor}.{patch}'.format(**self.cfg.semver.to_dict()),
+            "major_version": 'arangodb{major}{minor}'.format(**self.cfg.semver.to_dict()),
+            "bare_major_version": '{major}.{minor}'.format(**self.cfg.semver.to_dict()),
+            "remote_package_dir": self.inst.remote_package_dir,
+            "enterprise": "Enterprise" if enterprise else "Community",
+            "enterprise_magic": enterprise_magic + "/" if enterprise else "",
+            "packages": "" if is_nightly else "packages",
+            "nightly": "nightly" if is_nightly else ""
+        }
+        if is_nightly:
+            self.params['enterprise'] = ""
+
+        self.directories = {
+            "ftp:stage1": '/buildfiles/stage1/{full_version}/release/packages/{enterprise}/{remote_package_dir}/'.format(**self.params),
+            "ftp:stage2": '/buildfiles/stage2/{nightly}/{bare_major_version}/{packages}/{enterprise}/{remote_package_dir}/'.format(**self.params),
+            "http:stage1": 'stage1/{full_version}/release/packages/{enterprise}/{remote_package_dir}/'.format(**self.params),
+            "http:stage2": 'stage2/{nightly}/{bare_major_version}/{packages}/{enterprise}/{remote_package_dir}/'.format(**self.params),
+            "public": '{enterprise_magic}{major_version}/{enterprise}/{remote_package_dir}/'.format(**self.params)
+        }
+        self.funcs = {
+            "http:stage1": self.acquire_stage1_http,
+            "http:stage2": self.acquire_stage2_http,
+            "ftp:stage1": self.acquire_stage1_ftp,
+            "ftp:stage2": self.acquire_stage2_ftp,
+            "public": self.acquire_live
+        }
+
+    def acquire_stage_ftp(self, directory, package, local_dir, force, stage):
+        out = local_dir / package
+        if out.exists() and not force:
+            print(stage + ": not overwriting {file} since not forced to overwrite!".format(**{
+                "file": str(out)
             }))
-
-def acquire_stage1_http(directory, package, local_dir, force):
-    acquire_stage_http(directory, package, local_dir, force, "STAGE_1_HTTP")
-
-def acquire_stage2_http(directory, package, local_dir, force):
-    acquire_stage_http(directory, package, local_dir, force, "STAGE_2_HTTP")
-
-def acquire_stage1_ftp(directory, package, local_dir, force):
-    acquire_stage_ftp(directory, package, local_dir, force, "STAGE_1_FTP")
-
-def acquire_stage2_ftp(directory, package, local_dir, force):
-    acquire_stage_ftp(directory, package, local_dir, force, "STAGE_2_FTP")
-
-def acquire_live(directory, package, local_dir, force):
-    print('live')
-    url = 'https://download.arangodb.com/{dir}{pkg}'.format(**{
-        'dir': directory,
-        'pkg': package
-        })
-
-    out = local_dir / package
-    if out.exists() and not force:
-        print("LIVE: not overwriting {file} since not forced to overwrite!".format(**{
-            "file": str(out)
-        }))
-        return
-    print("LIVE: downloading " + str(url))
-    res = requests.get(url)
-    if res.status_code == 200:
-        print("LIVE: writing {size} kbytes to {file}".format(**{
-            "size": str(len(res.content) / 1024),
-            "file": str(out)
-        }))
-        out.write_bytes(res.content)
-    else:
-        raise Exception("LIVE: failed to download {url} - {error} - {msg}".format(**{
-            "url": url,
-            "error": res.status_code,
-            "msg": res.text
+            return
+        ftp = FTP('Nas02.arangodb.biz')
+        print(stage + ": " + ftp.login(user='anonymous', passwd='anonymous', acct='anonymous'))
+        print(directory)
+        print(stage + ": " + ftp.cwd(directory))
+        ftp.set_pasv(True)
+        with out.open(mode='wb') as fd:
+            print(stage + ": downloading to " + str(out))
+            print(stage + ": " + ftp.retrbinary('RETR ' + package, fd.write))
+    
+    def acquire_stage_http(self, directory, package, local_dir, force, stage):
+        global passvoid, user
+        #url = 'https://{user}:{passvoid}@Nas02.arangodb.biz/{dir}{pkg}'.format(**{
+        #    'passvoid': passvoid,
+        #    'user': user,
+        #    'dir': directory,
+        #    'pkg': package
+        #    })
+    
+        url = 'https://{self.user}:{self.passvoid}@fileserver.arangodb.com:8529/{dir}{pkg}'.format(**{
+            'passvoid': passvoid,
+            'user': user,
+            'dir': directory,
+            'pkg': package
+            })
+    
+        out = local_dir / package
+        if out.exists() and not force:
+            print(stage + ": not overwriting {file} since not forced to overwrite!".format(**{
+                "file": str(out)
             }))
+            return
+        print(stage + ": downloading " + str(url))
+        res = requests.get(url)
+        if res.status_code == 200:
+            print(stage + ": writing {size} kbytes to {file}".format(**{
+                "size": str(len(res.content) / 1024),
+                "file": str(out)
+            }))
+            out.write_bytes(res.content)
+        else:
+            raise Exception(stage + ": failed to download {url} - {error} - {msg}".format(**{
+                "url": url,
+                "error": res.status_code,
+                "msg": res.text
+                }))
+    
+    def acquire_stage1_http(self, directory, package, local_dir, force):
+        self.acquire_stage_http(directory, package, local_dir, force, "STAGE_1_HTTP")
+    
+    def acquire_stage2_http(self, directory, package, local_dir, force):
+        self.acquire_stage_http(directory, package, local_dir, force, "STAGE_2_HTTP")
+    
+    def acquire_stage1_ftp(self, directory, package, local_dir, force):
+        self.acquire_stage_ftp(directory, package, local_dir, force, "STAGE_1_FTP")
+    
+    def acquire_stage2_ftp(self, directory, package, local_dir, force):
+        self.acquire_stage_ftp(directory, package, local_dir, force, "STAGE_2_FTP")
+    
+    def acquire_live(self, directory, package, local_dir, force):
+        print('live')
+        url = 'https://download.arangodb.com/{dir}{pkg}'.format(**{
+            'dir': directory,
+            'pkg': package
+            })
+    
+        out = local_dir / package
+        if out.exists() and not force:
+            print("LIVE: not overwriting {file} since not forced to overwrite!".format(**{
+                "file": str(out)
+            }))
+            return
+        print("LIVE: downloading " + str(url))
+        res = requests.get(url)
+        if res.status_code == 200:
+            print("LIVE: writing {size} kbytes to {file}".format(**{
+                "size": str(len(res.content) / 1024),
+                "file": str(out)
+            }))
+            out.write_bytes(res.content)
+        else:
+            raise Exception("LIVE: failed to download {url} - {error} - {msg}".format(**{
+                "url": url,
+                "error": res.status_code,
+                "msg": res.text
+                }))
+    def get_packages(self, force, source):
+        packages = [
+            self.inst.server_package
+        ]
+        if self.inst.client_package:
+            packages.append(inst.client_package)
+        if self.inst.debug_package:
+            self.packages.append(inst.debug_package)
+    
+        for package in packages:
+            self.funcs[source](self.directories[source], package, Path(self.package_dir), force)
+
+    def get_version_info(self, source):
+        sl = 'sourceInfo.log'
+        self.funcs[source](self.directories[source], sl, Path(self.package_dir), True)
+        return (self.package_dir / sl).read_text()
 
 @click.command()
 @click.option('--version', help='ArangoDB version number.')
@@ -146,73 +232,10 @@ def acquire_live(directory, package, local_dir, force):
               default="",
               help='passvoid for external http download')
 
-def acquire_package(version, verbose, package_dir, enterprise, enterprise_magic, zip, force, source, httpuser, httppassvoid):
-    global passvoid, user
-    """ main """
-    lh.section("configuration")
-    print("version: " + str(version))
-    print("using enterpise: " + str(enterprise))
-    print("using zip: " + str(zip))
-    print("package directory: " + str(package_dir))
-    print("verbose: " + str(verbose))
-    user = httpuser
-    passvoid = httppassvoid
-
-    lh.section("startup")
-    if verbose:
-        logging.info("setting debug level to debug (verbose)")
-        logging.getLogger().setLevel(logging.DEBUG)
-
-    cfg = InstallerConfig(version,
-                          verbose,
-                          enterprise,
-                          zip,
-                          Path(package_dir),
-                          Path("/"),
-                          "",
-                          "127.0.0.1",
-                          False,
-                          False)
-
-    inst = make_installer(cfg)
-
-    params = {
-        "full_version": 'v{major}.{minor}.{patch}'.format(**cfg.semver.to_dict()),
-        "major_version": 'arangodb{major}{minor}'.format(**cfg.semver.to_dict()),
-        "bare_major_version": '{major}.{minor}'.format(**cfg.semver.to_dict()),
-        "remote_package_dir": inst.remote_package_dir,
-        "enterprise": "Enterprise" if enterprise else "Community",
-        "enterprise_magic": enterprise_magic + "/" if enterprise else ""
-    }
-
-    print(params)
-    directories = {
-        "ftp:stage1": '/buildfiles/stage1/{full_version}/release/packages/{enterprise}/{remote_package_dir}/'.format(**params),
-        "ftp:stage2": '/buildfiles/stage2/{bare_major_version}/packages/{enterprise}/{remote_package_dir}/'.format(**params),
-        "http:stage1": 'stage1/{full_version}/release/packages/{enterprise}/{remote_package_dir}/'.format(**params),
-        "http:stage2": 'stage2/{bare_major_version}/packages/{enterprise}/{remote_package_dir}/'.format(**params),
-        "public": '{enterprise_magic}{major_version}/{enterprise}/{remote_package_dir}/'.format(**params)
-    }
-
-    funcs = {
-        "http:stage1": acquire_stage1_http,
-        "http:stage2": acquire_stage2_http,
-        "ftp:stage1": acquire_stage1_ftp,
-        "ftp:stage2": acquire_stage2_ftp,
-        "public": acquire_live
-    }
-
-    print(directories)
-    packages = [
-        inst.server_package
-    ]
-    if inst.client_package:
-        packages.append(inst.client_package)
-    if inst.debug_package:
-        packages.append(inst.debug_package)
-
-    for package in packages:
-        funcs[source](directories[source], package, Path(package_dir), force)
+def main(version, verbose, package_dir, enterprise, enterprise_magic, zip, force, source, httpuser, httppassvoid):
+    
+    dl = acquire_package(version, verbose, package_dir, enterprise, enterprise_magic, zip, httpuser, httppassvoid)
+    return dl.get_packages(force, source)
 
 if __name__ == "__main__":
-    sys.exit(acquire_package())
+    sys.exit(main())

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -286,7 +286,7 @@ arangod instance
             self.pid = int(pid)
             # locate the timestamp of our 'ready for business' line:
             match = re.search(r'(.*)Z \['+pid+'].*' + ready_for_business,
-                              log_file_content[pos - 90:])
+                              log_file_content[pos - 140:])
             tStart = match.group(1)
             logging.debug("found pid {0} for instance with logfile {1} at {2}.".format(
                 self.pid,

--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -179,7 +179,7 @@ class Dc2Dc(Runner):
                 print(res[1])
             raise Exception("error during verifying of the test data on the target cluster")
         rc = self.cluster1['instance'].arangosh.run_in_arangosh(
-            Path('test_data/tests/js/server/replication/fuzz/replication-fuzz-global.js'),
+            self.cfg.test_data_dir / Path('tests/js/server/replication/fuzz/replication-fuzz-global.js'),
             [],
             [self.cluster2['instance'].get_frontend().get_public_url('')]
             )

--- a/release_tester/arangodb/starter/deployments/leaderfollower.py
+++ b/release_tester/arangodb/starter/deployments/leaderfollower.py
@@ -165,7 +165,7 @@ process.exit(0);
         # add instace where makedata will be run on
         self.tcp_ping_all_nodes()
         rc = self.leader_starter_instance.arangosh.run_in_arangosh(
-            Path('test_data/tests/js/server/replication/fuzz/replication-fuzz-global.js'),
+            self.cfg.test_data_dir / Path('tests/js/server/replication/fuzz/replication-fuzz-global.js'),
             [],
             [self.follower_starter_instance.get_frontend().get_public_url('')]
             )

--- a/release_tester/arangodb/starter/manager.py
+++ b/release_tester/arangodb/starter/manager.py
@@ -45,6 +45,9 @@ class StarterManager():
         if self.cfg.verbose:
             self.moreopts += ["--log.verbose=true"]
             # self.moreopts += ['--all.log', 'startup=debug']
+        #self.moreopts += ["--all.log.level=arangosearch=trace"]
+        #self.moreopts += ["--all.log.level=startup=trace"]
+        #self.moreopts += ["--all.log.level=engines=trace"]
 
         #directories
         self.raw_basedir = install_prefix

--- a/release_tester/upgrade.py
+++ b/release_tester/upgrade.py
@@ -18,47 +18,10 @@ logging.basicConfig(
     format='%(asctime)s %(levelname)s %(filename)s:%(lineno)d - %(message)s'
 )
 
-
-@click.command()
-@click.option('--old-version', help='old ArangoDB version number.')
-@click.option('--version', help='ArangoDB version number.')
-@click.option('--verbose/--no-verbose',
-              is_flag=True,
-              default=False,
-              help='switch starter to verbose logging mode.')
-@click.option('--package-dir',
-              default='/tmp/',
-              help='directory to load the packages from.')
-@click.option('--test-data-dir',
-              default='/tmp/',
-              help='directory create databases etc. in.')
-@click.option('--enterprise/--no-enterprise',
-              is_flag=True,
-              default=False,
-              help='Enterprise or community?')
-@click.option('--zip/--no-zip',
-              is_flag=True,
-              default=False,
-              help='switch to zip or tar.gz package instead of default OS package')
-@click.option('--interactive/--no-interactive',
-              is_flag=True,
-              default=sys.stdout.isatty(),
-              help='wait for the user to hit Enter?')
-@click.option('--starter-mode',
-              default='all',
-              help='which starter environments to start - ' +
-              '[all|LF|AFO|CL|DC|none].')
-@click.option('--stress-upgrade',
-              is_flag=True,
-              default=False,
-              help='launch arangobench before starting the upgrade')
-@click.option('--publicip',
-              default='127.0.0.1',
-              help='IP for the click to browser hints.')
-def run_test(old_version, version, verbose,
-             package_dir, test_data_dir,
-             enterprise, zip, interactive,
-             starter_mode, stress_upgrade, publicip):
+def run_upgrade(old_version, version, verbose,
+                package_dir, test_data_dir,
+                enterprise, zip, interactive,
+                starter_mode, stress_upgrade, publicip):
     """ main """
     lh.section("configuration")
     print("old version: " + str(old_version))
@@ -139,6 +102,51 @@ def run_test(old_version, version, verbose,
         lh.section("remove residuals")
         new_inst.cleanup_system()
 
+@click.command()
+@click.option('--old-version', help='old ArangoDB version number.')
+@click.option('--version', help='ArangoDB version number.')
+@click.option('--verbose/--no-verbose',
+              is_flag=True,
+              default=False,
+              help='switch starter to verbose logging mode.')
+@click.option('--package-dir',
+              default='/tmp/',
+              help='directory to load the packages from.')
+@click.option('--test-data-dir',
+              default='/tmp/',
+              help='directory create databases etc. in.')
+@click.option('--enterprise/--no-enterprise',
+              is_flag=True,
+              default=False,
+              help='Enterprise or community?')
+@click.option('--zip/--no-zip',
+              is_flag=True,
+              default=False,
+              help='switch to zip or tar.gz package instead of default OS package')
+@click.option('--interactive/--no-interactive',
+              is_flag=True,
+              default=sys.stdout.isatty(),
+              help='wait for the user to hit Enter?')
+@click.option('--starter-mode',
+              default='all',
+              help='which starter environments to start - ' +
+              '[all|LF|AFO|CL|DC|none].')
+@click.option('--stress-upgrade',
+              is_flag=True,
+              default=False,
+              help='launch arangobench before starting the upgrade')
+@click.option('--publicip',
+              default='127.0.0.1',
+              help='IP for the click to browser hints.')
+
+def main(old_version, version, verbose,
+         package_dir, test_data_dir,
+         enterprise, zip, interactive,
+         starter_mode, stress_upgrade, publicip):
+    return run_upgrade(old_version, version, verbose,
+                       package_dir, test_data_dir,
+                       enterprise, zip, interactive,
+                       starter_mode, stress_upgrade, publicip)
 
 if __name__ == "__main__":
-    run_test()
+    main()

--- a/test_data/run_in_arangosh.js
+++ b/test_data/run_in_arangosh.js
@@ -7,7 +7,23 @@ const internal = require('internal');
 const platform = internal.platform;
 
 const makeDirectoryRecursive = require('fs').makeDirectoryRecursive;
-let killRemainingProcesses = require('@arangodb/process-utils').killRemainingProcesses;
+
+function killRemainingProcesses(results) {
+  let running = internal.getExternalSpawned();
+  results.status = results.status && (running.length === 0);
+  let i = 0;
+  for (i = 0; i < running.length; i++) {
+    let status = require("internal").statusExternal(running[i].pid, false);
+    if (status.status === "TERMINATED") {
+      print("process exited without us joining it (marking crashy): " + JSON.stringify(running[i]) + JSON.stringify(status));
+    }
+    else {
+      print("Killing remaining process & marking crashy: " + JSON.stringify(running[i]));
+      print(killExternal(running[i].pid, abortSignal));
+    }
+    results.crashed = true;
+  };
+}
 let SetGlobalExecutionDeadlineTo = require('internal').SetGlobalExecutionDeadlineTo;
 const inspect = internal.inspect;
 


### PR DESCRIPTION
- make acquire_packages.py class based, optionally useable via include
- split the `main` function from upgrade_packages.py so we can use it via include
- add tarball_nightly_test.py which will do the package downloading, version checking for delta, test execution.
- release_tester/arangodb/instance.py - snap length was to low for longer version numbers *lol*
- test_data/run_in_arangosh.js `process-utils.js` has been removed from the distribution tarballs - copy function required from there over.
- use absolute paths to the js-tests executed. 