### PR TITLE
Test SmartGraph Validators

### DIFF
--- a/release_tester/arangodb/sh.py
+++ b/release_tester/arangodb/sh.py
@@ -423,19 +423,16 @@ class ArangoshExecutor():
         else:
             logging.info("checking test data")
 
-        validate_one_shard = 'true' if semver.compare(self.cfg.version, "3.7.7") >= 0 else 'false'
-
         ret = self.run_script_monitored(cmd=[
             'checking test data integrity',
             self.cfg.test_data_dir / 'checkdata.js'],
                                             args=args + [
                                                 '--progress', 'true',
-                                                '--validateoneshard', validate_one_shard
+                                                '--oldVersion', self.cfg.version
                                             ],
                                         timeout=5,
                                         result_line=result_line,
                                         verbose=self.cfg.verbose)
-
         return ret
 
     def clear_test_data(self, testname, args=[], result_line=dummy_line_result):

--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -8,6 +8,11 @@ const internal = require('internal')
 const time = internal.time;
 let db = internal.db;
 let print = internal.print;
+const isCluster = require("internal").isCluster();
+const  dbVersion = db._version();
+
+const { FeatureFlags } = require("./test_data/feature_flags");
+
 let database = "_system";
 
 const optionsDefaults = {
@@ -18,8 +23,8 @@ const optionsDefaults = {
   collectionMultiplier: 1,
   singleShard: false,
   progress: false,
-  validateOneShard: false
-}
+  oldVersion: "3.8.0"
+};
 
 if ((0 < ARGUMENTS.length) &&
     (ARGUMENTS[0].slice(0, 1) !== '-')) {
@@ -29,6 +34,7 @@ if ((0 < ARGUMENTS.length) &&
 
 let options = internal.parseArgv(ARGUMENTS, 0);
 _.defaults(options, optionsDefaults);
+
 
 var numberLength = Math.log(options.numberOfDBs + options.countOffset) * Math.LOG10E + 1 | 0;
 
@@ -43,6 +49,8 @@ function progress() {
     print("#");
   }
 }
+
+const flags = new FeatureFlags(dbVersion, options.oldVersion);
  
 function getShardCount(defaultShardCount) {
   if (options.singleShard) {
@@ -78,6 +86,60 @@ function validateDocumentWorksInOneShard(db, baseName, count) {
       throw "DOCUMENT call in OneShard database does not return data";
     }
 
+  }
+}
+
+function testSmartGraphValidator(ccount) {
+  if (!isCluster || !flags.hasSmartGraphValidator()) {
+    // Feature does not exist, no need to test:
+    return {fail: false};
+  }
+  // Feature does not exist, no need to test:
+  try {
+    const vColName = `patents_smart_${ccount}`;
+    const eColName = `citations_smart_${ccount}`;
+    const gName = `G_smart_${ccount}`;
+    const remoteDocument = {_key: "abc:123::def", _from: `${vColName}/abc:123`, _to: `${vColName}/def:123`};
+    const localDocument = {_key: "abc:123::abc", _from: `${vColName}/abc:123`, _to: `${vColName}/abc:123`};
+    const testValidator = (colName, doc) => {
+      let col = db._collection(colName);
+      if (!col) {
+        return {
+          fail: true,
+          message: `The smartGraph "${gName}" was not created correctly, collection ${colName} missing`
+        };
+      }
+      try {
+        col.save(doc);
+        return {
+          fail: true,
+          message: `Validator did not trigger on collection ${colName} stored illegal document`
+        };
+      } catch (e) {
+        return {
+          fail: true,
+          message: `Validator returned ${JSON.stringify(e)}`
+        };
+      }
+      return {fail: false};
+    }
+    // We try to insert a document into the wrong shard. This should be rejected by the internal validator
+    let res = testValidator(`_local_${eColName}`, remoteDocument);
+    if (res.fail) {
+      return res;
+    }
+    res = testValidator(`_from_${eColName}`, localDocument);
+    if (res.fail) {
+      return res;
+    }
+    res = testValidator(`_to_${eColName}`, localDocument);
+    if (res.fail) {
+      return res;
+    }
+    return {fail: false};
+  } finally {
+    // Always report that we tested SmartGraph Validators
+    progress("Tested SmartGraph validators");
   }
 }
 
@@ -177,22 +239,29 @@ while (count < options.numberOfDBs) {
                  RETURN v`).toArray().length !== 6) { throw "Physalis"; }
     progress();
     if (enterprise){
-      let patents_smart = db._collection(`patents_smart_${ccount}`)
+      const vColName = `patents_smart_${ccount}`;
+      let patents_smart = db._collection(vColName);
       if (patents_smart.count() !== 761) { throw "Cherry"; }
       progress();
-      let citations_smart = db._collection(`citations_smart_${ccount}`)
+      const eColName = `citations_smart_${ccount}`;
+      let citations_smart = db._collection(eColName);
       if (citations_smart.count() !== 1000) { throw "Liji"; }
       progress();
+      const gName = `G_smart_${ccount}`;
       if (db._query(`FOR v, e, p IN 1..10 OUTBOUND "${patents_smart.name()}/US:3858245" 
-                   GRAPH "G_smart_${ccount}"
+                   GRAPH "${gName}"
                    RETURN v`).toArray().length !== 6) { throw "Black Currant"; }
       progress();
+      const res = testSmartGraphValidator(ccount);
+      if (res.fail) {
+        throw res.message;
+      }
     }
     ccount ++;
   }
   print(timeLine.join());
-  
-  if (options.validateOneShard) {
+
+  if (flags.shouldValidateOneShard()) {
     validateDocumentWorksInOneShard(db, database, count);
   }
   count ++;

--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -94,7 +94,6 @@ function testSmartGraphValidator(ccount) {
     // Feature does not exist, no need to test:
     return {fail: false};
   }
-  // Feature does not exist, no need to test:
   try {
     const vColName = `patents_smart_${ccount}`;
     const eColName = `citations_smart_${ccount}`;

--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -99,8 +99,8 @@ function testSmartGraphValidator(ccount) {
     const vColName = `patents_smart_${ccount}`;
     const eColName = `citations_smart_${ccount}`;
     const gName = `G_smart_${ccount}`;
-    const remoteDocument = {_key: "abc:123::def", _from: `${vColName}/abc:123`, _to: `${vColName}/def:123`};
-    const localDocument = {_key: "abc:123::abc", _from: `${vColName}/abc:123`, _to: `${vColName}/abc:123`};
+    const remoteDocument = {_key: "abc:123:def", _from: `${vColName}/abc:123`, _to: `${vColName}/def:123`};
+    const localDocument = {_key: "abc:123:abc", _from: `${vColName}/abc:123`, _to: `${vColName}/abc:123`};
     const testValidator = (colName, doc) => {
       let col = db._collection(colName);
       if (!col) {
@@ -116,10 +116,13 @@ function testSmartGraphValidator(ccount) {
           message: `Validator did not trigger on collection ${colName} stored illegal document`
         };
       } catch (e) {
-        return {
-          fail: true,
-          message: `Validator returned ${JSON.stringify(e)}`
-        };
+        // We only allow the following two errors, all others should be reported.
+        if (e.errorNum != 1466 && e.errorNum != 1233) {
+          return {
+            fail: true,
+            message: `Validator of collection ${colName} on atempt to store ${doc} returned unexpected error ${JSON.stringify(e)}`
+          };
+        }
       }
       return {fail: false};
     }

--- a/test_data/feature_flags.js
+++ b/test_data/feature_flags.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const semver = require('semver');
+
+class FeatureFlags {
+  // OldVersion is optional and used in case of upgrade.
+  // It resambles the version we are upgradeing from
+  // Current is the version of the database we are attached to
+  constructor(currentVersion, oldVersion = "") {
+    if (oldVersion === "") {
+      oldVersion = currentVersion;
+    }
+    this._old = semver.parse(semver.coerce(oldVersion));
+    this._current = semver.parse(semver.coerce(currentVersion));
+  }
+
+  hasSmartGraphValidator() {
+    return semver.gte(this._current, "3.9.0");
+  }
+
+  shouldValidateOneShard() {
+    return semver.gte(this._old, "3.7.7");
+  }
+};
+
+exports.FeatureFlags = FeatureFlags;


### PR DESCRIPTION
Adds a test for SmartGraph validators, which will be introduced in 3.9.0
Also adds some environment around this, s.t. a test can figure out which version it has and which tests It need to execute.

Note:
This PR can only be merged AFTER the SmartGraphValidators are merged into devel. Otherwise we expected 3.8.* -> 3.9.* Jenkins run to always fail.