### PR TITLE
Fix several parts to run on Windows

### DIFF
--- a/release_tester/arangodb/installers/nsis.py
+++ b/release_tester/arangodb/installers/nsis.py
@@ -7,6 +7,7 @@ import multiprocessing
 from pathlib import Path
 from pathlib import PureWindowsPath
 import psutil
+import subprocess
 from arangodb.installers.base import InstallerBase
 
 class InstallerW(InstallerBase):
@@ -167,7 +168,7 @@ class InstallerW(InstallerBase):
         if not self.service:
             logging.error("no service registered, not starting")
             return
-        self.service.start()
+        subprocess.Popen("sc start ArangoDB", shell=True, stdout=subprocess.PIPE)
         while self.service.status() != "running":
             logging.info(self.service.status())
             time.sleep(1)
@@ -178,12 +179,11 @@ class InstallerW(InstallerBase):
         self.instance.detect_pid(1)
 
     def stop_service(self):
-        self.get_service()
         if not self.service:
             logging.error("no service registered, not stopping")
             return
         if self.service.status() != "stopped":
-            self.service.stop()
+            subprocess.Popen("sc stop ArangoDB", shell=True, stdout=subprocess.PIPE)
         while self.service.status() != "stopped":
             logging.info(self.service.status())
             time.sleep(1)

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -5,6 +5,8 @@ import datetime
 from enum import IntEnum
 import json
 import logging
+import os
+from pathlib import Path
 import re
 import time
 
@@ -110,6 +112,8 @@ class Instance(ABC):
         logfile = str(self.logfile)
         logging.info("renaming instance logfile: %s -> %s",
                      logfile, logfile + '.old')
+        if Path(logfile + '.old').exists():
+            os.remove(Path(logfile + '.old'))
         self.logfile.rename(logfile + '.old')
 
     def terminate_instance(self):


### PR DESCRIPTION
- use another Windows service start/stop (psutil doesn't have it yet)
- use another approach to kill Starter and it's descendants on Windows with another expectations (https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess is always positive)
- remove existing copy of `arangod.log` prior to call `<Path>.rename(<new\path>)` because it doesn't do overwrite on Windows