### PR TITLE
Zirkus/reverse bugfix smartgarph validators

### DIFF
--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -90,10 +90,6 @@ function validateDocumentWorksInOneShard(db, baseName, count) {
 }
 
 function testSmartGraphValidator(ccount) {
-  // Temporarily disable Validator Tests.
-  // Due to our missconfigured jenkins it was impossible to test
-  // this before merge, now it is all broken and needs time to be fixed.
-  return {fail : false};
   if (!isCluster || !flags.hasSmartGraphValidator()) {
     // Feature does not exist, no need to test:
     return {fail: false};

--- a/test_data/makedata.js
+++ b/test_data/makedata.js
@@ -416,9 +416,7 @@ while (count < options.numberOfDBs) {
     progress('loadGraph1');
 
     // And now a smart graph (if enterprise):
-    // NOTE: Temporarily disabled SmartGraph tests. This crashes the hotbackup.
-    // Tests for now and needs fixing.
-    if (enterprise && false) {
+    if (enterprise) {
       let Gsm = createSafe(`G_smart_${ccount}`, graphName => {
         return gsm._create(graphName,
                            [


### PR DESCRIPTION
This is a pure Jenkins circus revert PR.

It is impossible to test a branch under upgrade.
If this suite needs to server for upgrade tests we need to be able to do this.
Now we have merged something into devel which seems to not pass all of the upgrade tests.
We had to temporarily disable large portions of this framework, namely smart graphs and need to revisit a PR merged over a week ago.

This process is absolutely unsatisfying and time wasting.