### PR TITLE
ignore encoding

### DIFF
--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -185,7 +185,7 @@ class Instance(ABC):
             return
         print(str(self.logfile))
         count = 0
-        with open(self.logfile) as log_fh:
+        with open(self.logfile, errors='ignore') as log_fh:
             for line in log_fh:
                 if self.is_line_relevant(line):
                     if self.is_suppressed_log_line(line):
@@ -333,7 +333,7 @@ class ArangodInstance(Instance):
         while True:
             log_file_content = ""
             last_line = ''
-            with open(self.logfile) as log_fh:
+            with open(self.logfile, errors='ignore') as log_fh:
                 for line in log_fh:
                     # skip empty lines
                     if line == "":
@@ -378,7 +378,7 @@ class ArangodInstance(Instance):
     def detect_fatal_errors(self):
         """ check whether we have FATAL lines in the logfile """
         fatal_line = None
-        with open(self.logfile) as log_fh:
+        with open(self.logfile, errors='ignore') as log_fh:
             for line in log_fh:
                 if fatal_line is not None:
                     fatal_line += "\n" + line
@@ -400,7 +400,15 @@ class ArangodInstance(Instance):
             log_file_content = ''
             last_line = ''
 
-            with open(self.logfile) as log_fh:
+            for n in range(10):
+                if self.logfile.exists():
+                    break
+                else:
+                    time.sleep(1)
+            else:
+                raise TimeoutException("instance logfile didn't show up in 10 seconds")
+
+            with open(self.logfile, errors='ignore') as log_fh:
                 for line in log_fh:
                     # skip empty lines
                     if line == "":
@@ -489,7 +497,7 @@ class ArangodInstance(Instance):
         if not self.logfile.exists():
             print(str(self.logfile) + " doesn't exist, skipping.")
             return self.serving
-        with open(self.logfile) as log_fh:
+        with open(self.logfile, errors='ignore') as log_fh:
             for line in log_fh:
                 if 'a66dc' in line:
                     serving_line = line
@@ -546,7 +554,7 @@ class SyncInstance(Instance):
         cmd = []
         # we search for the logfile parameter, since its unique to our instance.
         logfile_parameter = ''
-        with open(command) as filedesc:
+        with open(command, errors='ignore') as filedesc:
             for line in filedesc.readlines():
                 line = line.rstrip().rstrip(' \\')
                 if line.find('--log.file') >=0:

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -185,7 +185,7 @@ class Instance(ABC):
             return
         print(str(self.logfile))
         count = 0
-        with open(self.logfile, errors='ignore') as log_fh:
+        with open(self.logfile, errors='backslashreplace') as log_fh:
             for line in log_fh:
                 if self.is_line_relevant(line):
                     if self.is_suppressed_log_line(line):
@@ -333,7 +333,7 @@ class ArangodInstance(Instance):
         while True:
             log_file_content = ""
             last_line = ''
-            with open(self.logfile, errors='ignore') as log_fh:
+            with open(self.logfile, errors='backslashreplace') as log_fh:
                 for line in log_fh:
                     # skip empty lines
                     if line == "":
@@ -378,7 +378,7 @@ class ArangodInstance(Instance):
     def detect_fatal_errors(self):
         """ check whether we have FATAL lines in the logfile """
         fatal_line = None
-        with open(self.logfile, errors='ignore') as log_fh:
+        with open(self.logfile, errors='backslashreplace') as log_fh:
             for line in log_fh:
                 if fatal_line is not None:
                     fatal_line += "\n" + line
@@ -407,7 +407,7 @@ class ArangodInstance(Instance):
             else:
                 raise TimeoutError("instance logfile didn't show up in 10 seconds")
 
-            with open(self.logfile, errors='ignore') as log_fh:
+            with open(self.logfile, errors='backslashreplace') as log_fh:
                 for line in log_fh:
                     # skip empty lines
                     if line == "":
@@ -496,7 +496,7 @@ class ArangodInstance(Instance):
         if not self.logfile.exists():
             print(str(self.logfile) + " doesn't exist, skipping.")
             return self.serving
-        with open(self.logfile, errors='ignore') as log_fh:
+        with open(self.logfile, errors='backslashreplace') as log_fh:
             for line in log_fh:
                 if 'a66dc' in line:
                     serving_line = line
@@ -553,7 +553,7 @@ class SyncInstance(Instance):
         cmd = []
         # we search for the logfile parameter, since its unique to our instance.
         logfile_parameter = ''
-        with open(command, errors='ignore') as filedesc:
+        with open(command, errors='backslashreplace') as filedesc:
             for line in filedesc.readlines():
                 line = line.rstrip().rstrip(' \\')
                 if line.find('--log.file') >=0:

--- a/release_tester/arangodb/starter/manager.py
+++ b/release_tester/arangodb/starter/manager.py
@@ -236,7 +236,7 @@ class StarterManager():
         #pylint disable=W0703
         match_str = "--starter.data-dir={0.basedir}".format(self)
         if self.passvoidfile.exists():
-            self.passvoid = self.passvoidfile.read_text(errors='ignore')
+            self.passvoid = self.passvoidfile.read_text(errors='backslashreplace')
         for process in psutil.process_iter(['pid', 'name']):
             try:
                 name = process.name()
@@ -612,19 +612,19 @@ class StarterManager():
 
     def get_log_file(self):
         """ fetch the logfile of this starter"""
-        return self.log_file.read_text(errors='ignore')
+        return self.log_file.read_text(errors='backslashreplace')
 
     def read_db_logfile(self):
         """ get the logfile of the dbserver instance"""
         server = self.get_dbserver()
         assert server.logfile.exists(), "don't have logfile?"
-        return server.logfile.read_text(errors='ignore')
+        return server.logfile.read_text(errors='backslashreplace')
 
     def read_agent_logfile(self):
         """ get the agent logfile of this instance"""
         server = self.get_agent()
         assert server.logfile.exists(), "don't have logfile?"
-        return server.logfile.read_text(errors='ignore')
+        return server.logfile.read_text(errors='backslashreplace')
 
     def detect_instances(self):
         """ see which arangods where spawned and inspect their logfiles"""
@@ -828,7 +828,7 @@ class StarterManager():
             print(str(self.log_file) + " not there. Skipping search")
             return
         print(str(self.log_file))
-        with self.log_file.open(errors='ignore') as log_f:
+        with self.log_file.open(errors='backslashreplace') as log_f:
             for line in log_f.readline():
                 if ('WARN' in line or
                     'ERROR' in line):

--- a/release_tester/arangodb/starter/manager.py
+++ b/release_tester/arangodb/starter/manager.py
@@ -236,7 +236,7 @@ class StarterManager():
         #pylint disable=W0703
         match_str = "--starter.data-dir={0.basedir}".format(self)
         if self.passvoidfile.exists():
-            self.passvoid = self.passvoidfile.read_text()
+            self.passvoid = self.passvoidfile.read_text(errors='ignore')
         for process in psutil.process_iter(['pid', 'name']):
             try:
                 name = process.name()
@@ -612,19 +612,19 @@ class StarterManager():
 
     def get_log_file(self):
         """ fetch the logfile of this starter"""
-        return self.log_file.read_text()
+        return self.log_file.read_text(errors='ignore')
 
     def read_db_logfile(self):
         """ get the logfile of the dbserver instance"""
         server = self.get_dbserver()
         assert server.logfile.exists(), "don't have logfile?"
-        return server.logfile.read_text()
+        return server.logfile.read_text(errors='ignore')
 
     def read_agent_logfile(self):
         """ get the agent logfile of this instance"""
         server = self.get_agent()
         assert server.logfile.exists(), "don't have logfile?"
-        return server.logfile.read_text()
+        return server.logfile.read_text(errors='ignore')
 
     def detect_instances(self):
         """ see which arangods where spawned and inspect their logfiles"""
@@ -828,7 +828,7 @@ class StarterManager():
             print(str(self.log_file) + " not there. Skipping search")
             return
         print(str(self.log_file))
-        with self.log_file.open() as log_f:
+        with self.log_file.open(errors='ignore') as log_f:
             for line in log_f.readline():
                 if ('WARN' in line or
                     'ERROR' in line):


### PR DESCRIPTION
don't make us trip over vpack printed to logfiles:
```
2021-06-22T12:04:50Z [15459] ERROR [05196] {heartbeat} Failed to resolve leader endpointTraceback (most recent call last):
  File "/home/release-test-automation/release_tester/upgrade.py", line 76, in run_upgrade
    runner.run()
  File "/home/release-test-automation/release_tester/arangodb/starter/deployments/runner.py", line 314, in run
    self.jam_attempt()
  File "/home/release-test-automation/release_tester/arangodb/starter/deployments/runner.py", line 479, in jam_attempt
    self.jam_attempt_impl()
  File "/home/release-test-automation/release_tester/arangodb/starter/deployments/activefailover.py", line 185, in jam_attempt_impl
    node.detect_leader()
  File "/home/release-test-automation/release_tester/arangodb/starter/manager.py", line 772, in detect_leader
    lfs = self.read_db_logfile()
  File "/home/release-test-automation/release_tester/arangodb/starter/manager.py", line 621, in read_db_logfile
    return server.logfile.read_text()
  File "/usr/lib/python3.8/pathlib.py", line 1233, in read_text
    return f.read()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf7 in position 329773: invalid start byte

```