### PR TITLE
Feature/trigger agency failover

### DIFF
--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -129,6 +129,28 @@ class Instance(ABC):
         else:
             logging.info("I'm already dead, jim!" + str(repr(self)))
 
+    def suspend_instance(self):
+        """ halt an instance using SIG_STOP """
+        if self.instance:
+            try:
+                self.instance.suspend()
+            except psutil.NoSuchProcess:
+                logging.info("instance not available with this PID: " + str(self.instance))
+            self.instance = None
+        else:
+            logging.error("instance not available with this PID: " + str(repr(self)))
+
+    def resume_instance(self):
+        """ resume the instance using SIG_CONT """
+        if self.instance:
+            try:
+                self.instance.resume()
+            except psutil.NoSuchProcess:
+                logging.info("instance not available with this PID: " + str(self.instance))
+            self.instance = None
+        else:
+            logging.error("instance not available with this PID: " + str(repr(self)))
+
     def crash_instance(self):
         """ send SIG-11 to instance... """
         if self.instance:

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -427,7 +427,9 @@ class ArangodInstance(Instance):
                     break
                 time.sleep(1)
             else:
-                raise TimeoutError("instance logfile didn't show up in 10 seconds")
+                raise TimeoutError("instance logfile '" +
+                                   str(self.logfile) +
+                                   "' didn't show up in 20 seconds")
 
             with open(self.logfile, errors='backslashreplace') as log_fh:
                 for line in log_fh:

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -68,6 +68,7 @@ class Instance(ABC):
         self.type_str = list(INSTANCE_TYPE_STRING_MAP.keys())[int(self.instance_type.value)]
         self.port = port
         self.pid = None
+        self.ppid = None
         self.basedir = basedir
         self.logfile = logfile
         self.localhost = localhost
@@ -110,12 +111,12 @@ class Instance(ABC):
     def get_essentials(self):
         """ get the essential attributes of the class """
 
-    def rename_logfile(self):
+    def rename_logfile(self, suffix='.old'):
         """ to ease further analysis, move old logfile out of our way"""
         logfile = str(self.logfile)
         logging.info("renaming instance logfile: %s -> %s",
-                     logfile, logfile + '.old')
-        self.logfile.rename(logfile + '.old')
+                     logfile, logfile + suffix)
+        self.logfile.rename(logfile + suffix)
 
     def terminate_instance(self):
         """ terminate the process represented by this wrapper class """
@@ -415,6 +416,7 @@ class ArangodInstance(Instance):
         """ detect the instance """
         # pylint: disable=R0915 disable=R0914
         self.pid = 0
+        self.ppid = ppid
         tries = 40
         t_start = ''
         while self.pid == 0 and tries:
@@ -573,6 +575,7 @@ class SyncInstance(Instance):
 
     def detect_pid(self, ppid, offset, full_binary_path):
         # first get the starter provided commandline:
+        self.ppid = ppid
         command = self.basedir / 'arangosync_command.txt'
         cmd = []
         # we search for the logfile parameter, since its unique to our instance.

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -122,6 +122,7 @@ class Instance(ABC):
         """ terminate the process represented by this wrapper class """
         if self.instance:
             try:
+                print('terminating instance {0}'.format(self.instance.pid))
                 self.instance.terminate()
                 self.instance.wait()
             except psutil.NoSuchProcess:
@@ -135,9 +136,9 @@ class Instance(ABC):
         if self.instance:
             try:
                 self.instance.suspend()
-            except psutil.NoSuchProcess:
+            except psutil.NoSuchProcess as ex:
                 logging.info("instance not available with this PID: " + str(self.instance))
-            self.instance = None
+                raise ex
         else:
             logging.error("instance not available with this PID: " + str(repr(self)))
 

--- a/release_tester/arangodb/instance.py
+++ b/release_tester/arangodb/instance.py
@@ -422,7 +422,7 @@ class ArangodInstance(Instance):
             log_file_content = ''
             last_line = ''
 
-            for _ in range(10):
+            for _ in range(20):
                 if self.logfile.exists():
                     break
                 time.sleep(1)

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -176,6 +176,7 @@ class ActiveFailover(Runner):
         # pylint: disable=R0915
         agency_leader = self.agency_get_leader()
         if self.first_leader.have_this_instance(agency_leader):
+            self.agency_trigger_leader_relection(agency_leader)
             print("AFO-Leader and agency leader are attached by the same starter!")
 
         self.first_leader.terminate_instance()

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -176,8 +176,8 @@ class ActiveFailover(Runner):
         # pylint: disable=R0915
         agency_leader = self.agency_get_leader()
         if self.first_leader.have_this_instance(agency_leader):
-            self.agency_trigger_leader_relection(agency_leader)
             print("AFO-Leader and agency leader are attached by the same starter!")
+            self.agency_trigger_leader_relection(agency_leader)
 
         self.first_leader.terminate_instance()
         logging.info("waiting for new leader...")

--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -743,7 +743,7 @@ class Runner(ABC):
 
     def agency_trigger_leader_relection(self, old_leader):
         """ halt one agent to trigger an agency leader re-election """
-        self.progress(True, "AGENCY pausing leader to trigger a failover")
+        self.progress(True, "AGENCY pausing leader to trigger a failover\n%s"%repr(old_leader))
         old_leader.suspend_instance()
         time.sleep(1)
         while True:
@@ -752,12 +752,7 @@ class Runner(ABC):
                 self.progress(True, "AGENCY failover has happened")
                 break
             time.sleep(1)
-        old_leader.rename_logfile('.before_trigger_leader_change')
         old_leader.resume_instance()
-        self.progress(True, "AGENCY killing instance and waiting for respawn")
-        old_leader.terminate_instance()
-        old_leader.detect_pid(old_leader.ppid)
-        self.progress(True, "AGENCY back online")
 
     def agency_get_leader(self):
         """ get the agent that has the latest "serving" line """

--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -737,6 +737,18 @@ class Runner(ABC):
         if testdir.exists():
             shutil.rmtree(testdir)
 
+    def agency_trigger_leader_relection(self, old_leader):
+        self.progress(False, "AGENCY stopping leader to trigger a failover")
+        old_leader.suspend_instance()
+        time.sleep(1)
+        while True:
+            new_leader = self.agency_get_leader()
+            if old_leader != new_leader:
+                self.progress(False, "AGENCY failover has happened")
+                break
+            time.sleep(1)
+        old_leader.resume_instance()
+
     def agency_get_leader(self):
         """ get the agent that has the latest "serving" line """
         # please note: dc2dc has two agencies, this function cannot


### PR DESCRIPTION
if we see that the agency leader is attached to the same starter as the active failover leader, try to move the agency leader to another instance by stop & cont 'ing the leader agend for some time. 