### PR TITLE
Abort on shard not failed over

### DIFF
--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -259,7 +259,7 @@ if (options.disabledDbserverUUID !== "") {
         serverList.forEach((server, index) => {
           if (index === 0 && server === options.disabledDbserverUUID) {
             ++found;
-            collections.push(c.name);
+            collections.push(c);
           }
         });
       });

--- a/test_data/tests/js/common/test-data/apps/crud/scripts/setup.js
+++ b/test_data/tests/js/common/test-data/apps/crud/scripts/setup.js
@@ -17,9 +17,9 @@ for (const localName of documentCollections) {
 }
 
 for (const localName of edgeCollections) {
-  const qualifiedName = module.context.collectionName(localName, { replicationFactor: 2 });
+  const qualifiedName = module.context.collectionName(localName);
   if (!db._collection(qualifiedName)) {
-    db._createEdgeCollection(qualifiedName);
+    db._createEdgeCollection(qualifiedName, { replicationFactor: 2 });
   } else if (module.context.isProduction) {
     console.debug(`collection ${qualifiedName} already exists. Leaving it untouched.`)
   }


### PR DESCRIPTION
`crud_yyyy` doesn't seem to be failover save. 
though [it should be created with rf 2](https://github.com/arangodb/release-test-automation/blob/main/test_data/tests/js/common/test-data/apps/crud/scripts/setup.js)