### PR TITLE
Better test for failover has happened

### DIFF
--- a/test_data/checkdata.js
+++ b/test_data/checkdata.js
@@ -256,12 +256,10 @@ if (options.disabledDbserverUUID !== "") {
     db._collections().map((c) => c.name()).forEach((c) => {
       let shards = db[c].shards(true);
       Object.values(shards).forEach((serverList) => {
-        serverList.forEach((server, index) => {
-          if (index === 0 && server === options.disabledDbserverUUID) {
-            ++found;
-            collections.push(c);
-          }
-        });
+        if (serverList.length > 0 && serverList[0] === options.disabledDbserverUUID) {
+          ++found;
+          collections.push(c);
+        }
       });
     });
     if (found > 0) {
@@ -283,6 +281,53 @@ if (options.disabledDbserverUUID !== "") {
     print(collection_data)
     throw("Still have collections bound to the failed server: " + JSON.stringify(collections));
   }
+  let shardDist = {};
+  count = 0;
+  print("waiting for all new leaders to assume leadership");
+  while (count < 500) {
+    collections = [];
+    found = 0;
+    let shardDist = arango.GET("/_admin/cluster/shardDistribution");
+    if (shardDist.code !== 200 || typeof shardDist.results !== "object") {
+      continue;
+    }
+    let cols = Object.keys(shardDist.results);
+    cols.forEach( (c) => {
+      let col = shardDist.results[c];
+      let shards = Object.keys(col.Plan);
+      shards.forEach( (s) => {
+        if (col.Plan[s].leader !== col.Current[s].leader) {
+          ++found;
+          collections.push([c, s]);
+        }
+      });
+    });
+    if (found > 0) {
+      print(found + ' found - Waiting - ' + JSON.stringify(collections));
+      internal.sleep(1);
+      count += 1;
+    } else {
+      break;
+    }
+  }
+  if (count > 499) {
+    let collection_data = "Still have collections with incomplete failover: ";
+    collections.forEach(col => {
+      print(col)
+      let shardDistInfoForCol = "";
+      if (shardDist.hasOwnProperty("results") &&
+          shardDist.results.hasOwnProperty(col)) {
+        shardDistInfoForCol = JSON.stringify(shardDist.results[col]);
+      }
+      collection_data += "\n" + JSON.stringify(col) + ":\n" +
+        JSON.stringify(db[col].shards(true)) + "\n" +
+        JSON.stringify(db[col].properties()) + "\n" +
+        shardDistInfoForCol;
+    });
+    print(collection_data)
+    throw("Still have collections with incomplete failover: " + JSON.stringify(collections));
+  }
+
   print("done - continuing test.")
 }
 


### PR DESCRIPTION
The following waiting condition was added after failing a single machine
before queries are tried again:

Wait first until the failed server has been replaced in the Plan for all
shards.

Once this has happened, wait until Plan and Current show the same server
for all shards according to `/_admin/cluster/shardDistribution`.

This establishes that not only the failover has been planned by the
Supervision, but that the new leader has actually taken on its job and
the system is usable again.

This was discovered in the nightly tests and is therefore covered by
tests.

Relevant ticket: https://arangodb.atlassian.net/browse/BTS-547
