### PR TITLE
try one more way to trap bts-440. 

### DIFF
--- a/release_tester/arangodb/async_client.py
+++ b/release_tester/arangodb/async_client.py
@@ -51,9 +51,11 @@ def convert_result(result_array):
 class CliExecutionException(Exception):
     """transport CLI error texts"""
 
-    def __init__(self, message, execution_result):
+    def __init__(self, message, execution_result, have_timeout):
+        super().__init__()
         self.execution_result = execution_result
         self.message = message
+        self.have_timeout = have_timeout
 
 
 class ArangoCLIprogressiveTimeoutExecutor:
@@ -176,7 +178,7 @@ class ArangoCLIprogressiveTimeoutExecutor:
             res = (False, timeout_str + convert_result(result), rc_exit, line_filter)
             if expect_to_fail:
                 return res
-            raise CliExecutionException("Execution failed.", res)
+            raise CliExecutionException("Execution failed.", res, have_timeout)
 
         if not expect_to_fail:
             if len(result) == 0:
@@ -189,4 +191,4 @@ class ArangoCLIprogressiveTimeoutExecutor:
             res = (True, "", 0, line_filter)
         else:
             res = (True, convert_result(result), 0, line_filter)
-        raise CliExecutionException("Execution was expected to fail, but exited successfully.", res)
+        raise CliExecutionException("Execution was expected to fail, but exited successfully.", res, have_timeout)

--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -312,7 +312,7 @@ class Dc2Dc(Runner):
         print("Arangosync v%s detected" % version)
         return semver.VersionInfo.parse(version)
 
-    def _stop_sync(self, timeout=120):
+    def _stop_sync(self, timeout=130):
         try:
             timeout_start = time.time()
             if self._is_higher_sync_version(SYNC_VERSIONS["150"], SYNC_VERSIONS["230"]):
@@ -326,7 +326,12 @@ class Dc2Dc(Runner):
                 _, _, _, _ = self.sync_manager.stop_sync(timeout, ["--ensure-in-sync=false"])
         except CliExecutionException as exc:
             self.state += "\n" + exc.execution_result[1]
-            raise Exception("failed to stop the synchronization") from exc
+            output = ""
+            if exc.have_timeout:
+                (result, output) = self.sync_manager.check_sync()
+                if result:
+                    print("CHECK SYNC OK!")
+            raise Exception("failed to stop the synchronization; check sync:" + output) from exc
 
         if not self._is_higher_sync_version(SYNC_VERSIONS["180"], SYNC_VERSIONS["260"]):
             print("Wait for the inactive replication on all clusters")


### PR DESCRIPTION
We see that it seems not to exit on time. We want to know what a check_sync would print in that case