### PR TITLE
optimize process detection

### DIFF
--- a/release_tester/tools/killall.py
+++ b/release_tester/tools/killall.py
@@ -20,7 +20,7 @@ def get_all_processes(kill_selenium):
     chromedrivers = []
     headleschromes = []
     logging.info("searching for leftover processes")
-    for process in psutil.process_iter(["pid", "name"]):
+    for process in psutil.Process().children(recursive=True):
         try:
             name = process.name()
             if name.startswith("arangodb"):


### PR DESCRIPTION
Look only for processes that are descendant of this process, to prevent interference with other arangodb deployments on the same machine.