### PR TITLE
Move dc2dc port

### DIFF
--- a/release_tester/arangodb/installers/base.py
+++ b/release_tester/arangodb/installers/base.py
@@ -651,8 +651,7 @@ class InstallerBase(ABC):
                 splitted = one_str.split(" ")
                 self.starter_versions[splitted[0]] = splitted[1]
                 print("Starter version: " + str(self.starter_versions))
-            return semver.VersionInfo.parse(self.starter_versions["Version"])
-        return self.starter_versions
+        return semver.VersionInfo.parse(self.starter_versions["Version"])
 
     def check_backup_is_created(self):
         """Check that backup was created after package upgrade"""

--- a/release_tester/arangodb/installers/tar.py
+++ b/release_tester/arangodb/installers/tar.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import logging
 from pathlib import Path
+import time
 import os
 
 from reporting.reporting_utils import step
@@ -146,17 +147,24 @@ class InstallerTAR(InstallerBase):
             print("Flushing pre-existing installation directory: " +
                   str(self.cfg.install_prefix))
             shutil.rmtree(self.cfg.install_prefix)
+            while self.cfg.install_prefix.exists():
+                print('.')
+                time.sleep(1)
         else:
             self.cfg.install_prefix.mkdir(parents=True)
+
+        extract_to = self.cfg.install_prefix / ".."
+        extract_to = extract_to.resolve()
+
         print(
             "extracting: "
             + str(self.cfg.package_dir / self.server_package)
             + " to "
-            + str(self.cfg.install_prefix / "..")
+            + str(extract_to)
         )
         shutil.unpack_archive(
             str(self.cfg.package_dir / self.server_package),
-            str(self.cfg.install_prefix / ".."),
+            str(extract_to),
         )
         logging.info("Installation successfull")
 

--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -229,10 +229,10 @@ class Dc2Dc(Runner):
                 moreopts=opts,
             )
             val["instance"].set_jwt_file(val["JWTSecret"])
-            if port is None:
+            if port == 7528:
                 val["instance"].is_leader = True
 
-        add_starter(self.cluster1, None)
+        add_starter(self.cluster1, port=7528)
         add_starter(self.cluster2, port=9528)
         self.starter_instances = [self.cluster1["instance"], self.cluster2["instance"]]
 
@@ -246,7 +246,6 @@ class Dc2Dc(Runner):
             inst.detect_instances()
             inst.detect_instance_pids()
             cluster["smport"] = inst.get_sync_master_port()
-
             url = "http://{host}:{port}".format(host=self.cfg.publicip, port=str(cluster["smport"]))
             reply = requests.get(url)
             logging.info(str(reply))


### PR DESCRIPTION
- move dc2dc first cluster port down, so we don't collide with the system install.
- fix starter version handling broken in recent commits
- make tar handling more robust against existing directories.