### PR TITLE
Adding force cleanup feature in case of test failure

### DIFF
--- a/release_tester/selenium_ui_test/pages/collection_page.py
+++ b/release_tester/selenium_ui_test/pages/collection_page.py
@@ -254,18 +254,6 @@ class CollectionPage(NavigationBarPage):
         time.sleep(3)
         self.webdriver.refresh()
 
-        # if name == 'TestDoc':
-        #     return [name, self.select_doc_collection_id]
-        # elif name == 'TestEdge':
-        #     return [name, self.select_edge_collection_id]
-        # elif name == 'Test':
-        #     return [name, self.select_test_doc_collection_id]
-        # else:
-        #     print('Collection is not existed!! \n')
-
-        # if is_cluster:
-        #     return ['TestDocRenamed', self.select_renamed_doc_collection_id]
-
 
     def checking_search_options(self, search):
         """Checking search functionality"""
@@ -493,71 +481,6 @@ class CollectionPage(NavigationBarPage):
         """Selecting index menu from collection"""
         self.click_submenu_entry("Indexes")
 
-    # def create_new_index_btn(self):
-    #     """Selecting index menu from collection"""
-    #     create_new_index_btn_sitem = self.locator_finder_by_id(self.create_new_index_btn_id)
-    #     create_new_index_btn_sitem.click()
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
-
-    # def select_index_type(self, value):
-    #     """Selecting type of index here: Geo, Persistent, Fulltext or TTL"""
-    #     self.select_value(self.select_index_type_id, value)
-
-    # def select_create_index_btn(self):
-    #     """Selecting index menu from collection"""
-    #     select_create_index_btn_sitem = self.locator_finder_by_id(self.select_create_index_btn_id)
-    #     select_create_index_btn_sitem.click()
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
-
-    # def creating_geo_index(self):
-    #     """Filling up all the information for geo index"""
-    #     select_geo_fields_sitem = self.locator_finder_by_hover_item_id(self.select_geo_fields_id)
-    #     select_geo_fields_sitem.send_keys("gfields").perform()
-    #     select_geo_name_sitem = self.locator_finder_by_hover_item_id(self.select_geo_name_id)
-    #     select_geo_name_sitem.send_keys("gname").perform()
-    #     self.locator_finder_by_hover_item_id(self.select_geo_json_id)
-    #     self.locator_finder_by_hover_item_id(self.select_geo_background_id)
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
-
-    # def creating_persistent_index(self):
-    #     """Filling up all the information for persistent index"""
-    #     select_persistent_fields_sitem = self.locator_finder_by_hover_item_id(self.select_persistent_fields_id)
-    #     select_persistent_fields_sitem.send_keys("pfields").perform()
-    #     select_persistent_name_sitem = self.locator_finder_by_hover_item_id(self.select_persistent_name_id)
-    #     select_persistent_name_sitem.send_keys("pname").perform()
-    #     self.locator_finder_by_hover_item_id(self.select_persistent_unique_id)
-    #     self.locator_finder_by_hover_item_id(self.select_persistent_sparse_id)
-    #     self.locator_finder_by_hover_item_id(self.select_persistent_duplicate_id)
-    #     self.locator_finder_by_hover_item_id(self.select_persistent_background_id)
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
-
-    # def creating_fulltext_index(self):
-    #     """Filling up all the information for Fulltext index"""
-    #     select_fulltext_field_sitem = self.locator_finder_by_hover_item_id(self.select_fulltext_field_id)
-    #     select_fulltext_field_sitem.send_keys("ffields").perform()
-    #     select_fulltext_name_sitem = self.locator_finder_by_hover_item_id(self.select_fulltext_name_id)
-    #     select_fulltext_name_sitem.send_keys("fname").perform()
-    #     select_fulltext_length_sitem = self.locator_finder_by_hover_item_id(self.select_fulltext_length_id)
-    #     select_fulltext_length_sitem.send_keys(100)
-    #     self.locator_finder_by_hover_item_id(self.select_fulltext_background_id)
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
-
-    # def creating_ttl_index(self):
-    #     """Filling up all the information for TTL index"""
-    #     select_ttl_field_sitem = self.locator_finder_by_hover_item_id(self.select_ttl_field_id)
-    #     select_ttl_field_sitem.send_keys("tfields").perform()
-    #     select_ttl_name_sitem = self.locator_finder_by_hover_item_id(self.select_ttl_name_id)
-    #     select_ttl_name_sitem.send_keys("tname").perform()
-    #     select_ttl_expiry_sitem = self.locator_finder_by_hover_item_id(self.select_ttl_expiry_id)
-    #     select_ttl_expiry_sitem.send_keys(1000)
-    #     self.locator_finder_by_hover_item_id(self.select_ttl_background_id)
-    #     time.sleep(2)
-    #     self.wait_for_ajax()
 
     def create_new_index(self, index_name, value, is_cluster):
         """ create a new Index """

--- a/release_tester/selenium_ui_test/pages/collection_page.py
+++ b/release_tester/selenium_ui_test/pages/collection_page.py
@@ -3,11 +3,9 @@
 import time
 import semver
 import traceback
-
-from selenium.common.exceptions import ElementNotInteractableException, TimeoutException
-
+from selenium.common.exceptions import ElementNotInteractableException, TimeoutException, NoSuchElementException
 from selenium_ui_test.pages.navbar import NavigationBarPage
-import semver
+
 
 # can't circumvent long lines.. nAttr nLines
 # pylint: disable=line-too-long disable=too-many-instance-attributes disable=too-many-statements disable=too-many-public-methods
@@ -690,6 +688,8 @@ class CollectionPage(NavigationBarPage):
         except TimeoutException:
             print("TimeoutException occurred! \n")
             print("Info: Collection has already been deleted or never created. \n")
+        except NoSuchElementException:
+            print('Element not found, which might be happen due to force cleanup.')
         except Exception as ex:
             traceback.print_exc()
             raise Exception("Critical Error occurred and need manual inspection!! \n") from ex

--- a/release_tester/selenium_ui_test/pages/collection_page.py
+++ b/release_tester/selenium_ui_test/pages/collection_page.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """ collection page object """
 import time
+import semver
 import traceback
 
 from selenium.common.exceptions import ElementNotInteractableException, TimeoutException
-import semver
 
 from selenium_ui_test.pages.navbar import NavigationBarPage
+import semver
 
 # can't circumvent long lines.. nAttr nLines
 # pylint: disable=line-too-long disable=too-many-instance-attributes disable=too-many-statements disable=too-many-public-methods
@@ -198,6 +199,73 @@ class CollectionPage(NavigationBarPage):
         create_new_collection_btn_sitem = self.locator_finder_by_id(self.create_new_collection_btn_id)
         create_new_collection_btn_sitem.click()
         time.sleep(3)
+    
+    def create_new_collections(self, name, doc_type, is_cluster):
+        """This method will create new collection based on their name and type"""
+        print('selecting collection tab \n')
+        select_collection_page_sitem = self.locator_finder_by_id(self.select_collection_page_id)
+        select_collection_page_sitem.click()
+        time.sleep(1)
+
+        print('Clicking on create new collection box \n')
+        select_create_collection_sitem = self.locator_finder_by_id(self.select_create_collection_id)
+        select_create_collection_sitem.click()
+        time.sleep(1)
+
+        print('Selecting new collection name \n')
+        select_new_collection_name_sitem = self.locator_finder_by_id(self.select_new_collection_name_id)
+        select_new_collection_name_sitem.click()
+        select_new_collection_name_sitem.send_keys(name)
+        time.sleep(1)
+
+        print(f'Selecting collection type for {name} \n')  # collection Document type where # '2' = Document, '3' = Edge
+        self.locator_finder_by_select(self.select_collection_type_id, doc_type)
+        time.sleep(1)
+
+        if is_cluster:
+            print(f'selecting number of Shards for the {name} \n')
+            shards = 'new-collection-shards'
+            shards_sitem = self.locator_finder_by_id(shards)
+            shards_sitem.click()
+            shards_sitem.clear()
+            shards_sitem.send_keys(9)
+            time.sleep(2)
+
+            print(f'selecting number of replication factor for {name} \n')
+            rf = 'new-replication-factor'
+            rf_sitem = self.locator_finder_by_id(rf)
+            rf_sitem.click()
+            rf_sitem.clear()
+            rf_sitem.send_keys(3)
+            time.sleep(2)
+
+        print(f'Selecting collection advance options for {name} \n')
+        select_advance_option_sitem = self.locator_finder_by_xpath(self.select_advance_option_id)
+        select_advance_option_sitem.click()
+        time.sleep(1)
+
+        # Selecting collection wait type where value # 0 = YES, '1' = NO)
+        self.locator_finder_by_select(self.wait_for_sync_id, 0)
+        time.sleep(1)
+
+        print(f'Selecting create button for {name} \n')
+        create_new_collection_btn_sitem = self.locator_finder_by_id(self.create_new_collection_btn_id)
+        create_new_collection_btn_sitem.click()
+        time.sleep(3)
+        self.webdriver.refresh()
+
+        # if name == 'TestDoc':
+        #     return [name, self.select_doc_collection_id]
+        # elif name == 'TestEdge':
+        #     return [name, self.select_edge_collection_id]
+        # elif name == 'Test':
+        #     return [name, self.select_test_doc_collection_id]
+        # else:
+        #     print('Collection is not existed!! \n')
+
+        # if is_cluster:
+        #     return ['TestDocRenamed', self.select_renamed_doc_collection_id]
+
 
     def checking_search_options(self, search):
         """Checking search functionality"""
@@ -293,11 +361,12 @@ class CollectionPage(NavigationBarPage):
         """getting_total_row_count"""
         # ATTENTION: this will only be visible & successfull if the browser window is wide enough!
         size = self.webdriver.get_window_size()
-        if size["width"] > 1000:
+        if (size["width"] > 1000):
             getting_total_row_count_sitem = self.locator_finder_by_xpath(self.getting_total_row_count_id, 20)
             return getting_total_row_count_sitem.text
-        print("your browser window is to narrow! " + str(size))
-        return "-1"
+        else:
+            print("your browser window is to narrow! " + str(size))
+            return "-1"
 
 
     def download_doc_as_json(self):
@@ -490,7 +559,7 @@ class CollectionPage(NavigationBarPage):
     #     time.sleep(2)
     #     self.wait_for_ajax()
 
-    def create_new_index(self, index_name, value, cluster_status):
+    def create_new_index(self, index_name, value, is_cluster):
         """ create a new Index """
         print(f"Creating {index_name} index started \n")
         create_new_index_btn_sitem = self.locator_finder_by_id(self.create_new_index_btn_id)
@@ -508,7 +577,7 @@ class CollectionPage(NavigationBarPage):
             self.select_persistent_name_id.send_keys("pname").perform()
             time.sleep(1)
 
-            if not cluster_status:
+            if not is_cluster:
                 self.select_persistent_unique_id = self.locator_finder_by_hover_item_id(
                     self.select_persistent_unique_id
                 )
@@ -681,7 +750,7 @@ class CollectionPage(NavigationBarPage):
         selector = """//div[contains(@class, 'tile')][@id='collection_%s']""" % collection_name
         self.locator_finder_by_xpath(selector).click()
 
-    def delete_collection(self, collection_name, collection_locator):
+    def delete_collection(self, collection_name, collection_locator, is_cluster):
         """This method will delete all the collection"""
         print(f"Deleting {collection_name} collection started \n")
         self.select_collection_page()
@@ -690,7 +759,7 @@ class CollectionPage(NavigationBarPage):
             self.locator_finder_by_xpath(collection_locator).click()
 
             # we don't care about the cluster specific things:
-            self.select_settings_tab(False)
+            self.select_settings_tab(is_cluster)
             self.select_delete_collection()
 
             print(f"Deleting {collection_name} collection Completed \n")

--- a/release_tester/selenium_ui_test/test_suites/collections_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/collections_test_suite.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """ collection testsuite """
 import semver
+import traceback
 from selenium_ui_test.test_suites.base_selenium_test_suite import BaseSeleniumTestSuite
 from selenium_ui_test.test_suites.base_test_suite import testcase
 
@@ -22,214 +23,243 @@ class CollectionsTestSuite(BaseSeleniumTestSuite):
         assert col.current_user() == "ROOT", "current user is root?"
         assert col.current_database() == "_SYSTEM", "current database is _system?"
 
-        print("Selecting collection tab\n")
-        col.select_collection_page()
+        self.exception = False
+        self.error = None
 
-        print("Creating new collection started \n")
-        col.select_create_collection()
-        print("Creating Document collection \n")
-        col.select_new_collection_name("TestDoc")
-        print("Creating Document type collection started \n")
-        col.select_collection_type(0)  # 0 for Doc type document
+        # print("Selecting collection tab\n")
+        # col.select_collection_page()
 
-        if self.is_cluster:
-            print("Selecting number of shards for the current collection \n")
-            col.select_number_of_shards(9)  # it takes number of shards as an argument
+        # print("Creating new collection started \n")
+        # col.select_create_collection()
+        # print("Creating Document collection \n")
+        # col.select_new_collection_name("TestDoc")
+        # print("Creating Document type collection started \n")
+        # col.select_collection_type(0)  # 0 for Doc type document
 
-            print("Selecting replication factor for the current collection \n")
-            col.select_replication_factor(3)  # it takes number of replication factor as an argument
+        # if self.is_cluster:
+        #     print("Selecting number of shards for the current collection \n")
+        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
 
-        col.select_advance_option()
-        print("Choosing wait type to YES \n")
-        col.wait_for_sync(1)
-        col.create_new_collection_btn()
-        print("Creating Document type collection completed \n")
+        #     print("Selecting replication factor for the current collection \n")
+        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
 
-        print("Creating Edge type collection\n")
-        col.select_create_collection()
-        col.select_new_collection_name("TestEdge")
-        col.select_collection_type(1)  # 1 for Edge type document
+        # col.select_advance_option()
+        # print("Choosing wait type to YES \n")
+        # col.wait_for_sync(1)
+        # col.create_new_collection_btn()
+        # print("Creating Document type collection completed \n")
 
-        if self.is_cluster:
-            print("Selecting number of shards for the current collection \n")
-            col.select_number_of_shards(9)  # it takes number of shards as an argument
+        # print("Creating Edge type collection\n")
+        # col.select_create_collection()
+        # col.select_new_collection_name("TestEdge")
+        # col.select_collection_type(1)  # 1 for Edge type document
 
-            print("Selecting replication factor for the current collection \n")
-            col.select_replication_factor(3)  # it takes number of replication factor as an argument
+        # if self.is_cluster:
+        #     print("Selecting number of shards for the current collection \n")
+        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
 
-        col.select_advance_option()
-        print("Choosing wait type to YES \n")
-        col.wait_for_sync(1)
-        col.create_new_collection_btn()
-        print("Creating new Edge collection completed \n")
+        #     print("Selecting replication factor for the current collection \n")
+        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
 
-        print("Creating new collection started \n")
-        col.select_create_collection()
-        print("Creating Document collection \n")
-        col.select_new_collection_name("Test")
-        print("Creating Document type collection started \n")
-        col.select_collection_type(0)  # 0 for Doc type document
+        # col.select_advance_option()
+        # print("Choosing wait type to YES \n")
+        # col.wait_for_sync(1)
+        # col.create_new_collection_btn()
+        # print("Creating new Edge collection completed \n")
 
-        if self.is_cluster:
-            print("Selecting number of shards for the current collection \n")
-            col.select_number_of_shards(9)  # it takes number of shards as an argument
+        # print("Creating new collection started \n")
+        # col.select_create_collection()
+        # print("Creating Document collection \n")
+        # col.select_new_collection_name("Test")
+        # print("Creating Document type collection started \n")
+        # col.select_collection_type(0)  # 0 for Doc type document
 
-            print("Selecting replication factor for the current collection \n")
-            col.select_replication_factor(3)  # it takes number of replication factor as an argument
+        # if self.is_cluster:
+        #     print("Selecting number of shards for the current collection \n")
+        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
 
-        col.select_advance_option()
-        print("Choosing wait type to YES \n")
-        col.wait_for_sync(1)
-        col.create_new_collection_btn()
-        print("Creating Document type collection completed \n")
+        #     print("Selecting replication factor for the current collection \n")
+        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
 
-        print("checking Search options\n")
-        print("Searching using keyword 'Doc'\n")
-        col.checking_search_options("Doc")
-        self.webdriver.refresh()
-        print("Searching using keyword 'Edge'\n")
-        col.checking_search_options("Edge")
-        self.webdriver.refresh()
-        print("Searching using keyword 'test'\n")
-        col.checking_search_options("Test")
-        self.webdriver.refresh()
+        # col.select_advance_option()
+        # print("Choosing wait type to YES \n")
+        # col.wait_for_sync(1)
+        # col.create_new_collection_btn()
+        # print("Creating Document type collection completed \n")
 
-        print("Selecting Settings\n")
-        col.select_collection_settings()
-        print("Displaying system's collection\n")
-        col.display_system_collection()
-        col.display_system_collection()  # Doing the reverse part
-        print("Displaying Document type collection\n")
-        col.display_document_collection()
-        col.display_document_collection()
-        print("Displaying Edge type collection\n")
-        col.display_edge_collection()
-        col.display_edge_collection()
-        print("Displaying status loaded collection\n")
-        col.select_status_loaded()
-        col.select_status_loaded()
-        # todo: some old bullshit.
-        # print("Displaying status unloaded collection\n")
-        # col.select_status_unloaded()
-        # col.select_status_unloaded()
-        self.webdriver.refresh()
-        print("Sorting collections by type\n")
-        col.select_collection_settings()
-        col.sort_by_type()
-        print("Sorting collections by descending\n")
-        col.sort_descending()
-        col.sort_descending()
-        print("Sorting collections by name\n")
-        col.sort_by_name()
+        try:
+            col.create_new_collections('TestDoc', 0, self.is_cluster)
+            col.create_new_collections('TestEdge', 1, self.is_cluster)
+            col.create_new_collections('Test', 0, self.is_cluster)
 
-        col.select_edge_collection_upload()
-        print("Uploading file to the collection started\n")
-        col.select_upload_btn()
-        print("Uploading json file\n")
-        col.select_choose_file_btn(str(self.test_data_dir / "ui_data" / "edges.json"))
-        col.select_confirm_upload_btn()
-        self.webdriver.refresh()  # in order to clear the screen before fetching data
-        print("Uploading " + col.getting_total_row_count() + " documents to the collection Completed\n")
-        print("Selecting size of the displayed\n")
+            print("checking Search options\n")
+            print("Searching using keyword 'Doc'\n")
+            col.checking_search_options("Doc")
+            self.webdriver.refresh()
+            print("Searching using keyword 'Edge'\n")
+            col.checking_search_options("Edge")
+            self.webdriver.refresh()
+            print("Searching using keyword 'test'\n")
+            col.checking_search_options("Test")
+            self.webdriver.refresh()
 
-        self.webdriver.back()
+            print("Selecting Settings\n")
+            col.select_collection_settings()
+            print("Displaying system's collection\n")
+            col.display_system_collection()
+            col.display_system_collection()  # Doing the reverse part
+            print("Displaying Document type collection\n")
+            col.display_document_collection()
+            col.display_document_collection()
+            print("Displaying Edge type collection\n")
+            col.display_edge_collection()
+            col.display_edge_collection()
+            print("Displaying status loaded collection\n")
+            col.select_status_loaded()
+            col.select_status_loaded()
+            # todo: some old bullshit.
+            # print("Displaying status unloaded collection\n")
+            # col.select_status_unloaded()
+            # col.select_status_unloaded()
+            self.webdriver.refresh()
+            print("Sorting collections by type\n")
+            col.select_collection_settings()
+            col.sort_by_type()
+            print("Sorting collections by descending\n")
+            col.sort_descending()
+            col.sort_descending()
+            print("Sorting collections by name\n")
+            col.sort_by_name()
 
-        col.select_collection("TestDoc")
-        print("Uploading file to the collection started\n")
-        col.select_upload_btn()
-        print("Uploading json file\n")
-        col.select_choose_file_btn(str(self.test_data_dir / "ui_data" / "names_100.json"))
-        col.select_confirm_upload_btn()
-        self.webdriver.refresh()  # in order to clear the screen before fetching data
-        print("Uploading " + col.getting_total_row_count() + " documents to the collection Completed\n")
-        print("Selecting size of the displayed\n")
+            col.select_edge_collection_upload()
+            print("Uploading file to the collection started\n")
+            col.select_upload_btn()
+            print("Uploading json file\n")
+            col.select_choose_file_btn(str(self.test_data_dir / "ui_data" / "edges.json"))
+            col.select_confirm_upload_btn()
+            self.webdriver.refresh()  # in order to clear the screen before fetching data
+            print("Uploading " + col.getting_total_row_count() + " documents to the collection Completed\n")
+            print("Selecting size of the displayed\n")
 
-        # print("Downloading Documents as JSON file\n")
-        # col.download_doc_as_json()
+            self.webdriver.back()
 
-        print("Filter collection by '_id'\n")
-        col.filter_documents(3)
-        col.filter_documents(1)
-        col.display_document_size(2)  # choosing 50 results to display
-        print("Traverse back and forth search result page 1 and 2\n")
-        col.traverse_search_pages()
-        print("Selecting hand selection button\n")
-        col.select_hand_pointer()
-        print("Select Multiple item using hand pointer\n")
-        col.select_multiple_item()
-        col.move_btn()
-        print("Multiple data moving into test collection\n")
-        col.move_doc_textbox("Test")
-        col.move_confirm_btn()
+            col.select_collection("TestDoc")
+            print("Uploading file to the collection started\n")
+            col.select_upload_btn()
+            print("Uploading json file\n")
+            col.select_choose_file_btn(str(self.test_data_dir / "ui_data" / "names_100.json"))
+            col.select_confirm_upload_btn()
+            self.webdriver.refresh()  # in order to clear the screen before fetching data
+            print("Uploading " + col.getting_total_row_count() + " documents to the collection Completed\n")
+            print("Selecting size of the displayed\n")
 
-        print("Deleting multiple data started\n")
-        col.select_multiple_item()
-        col.select_collection_delete_btn()
-        col.collection_delete_confirm_btn()
-        col.collection_really_dlt_btn()
-        print("Deleting multiple data completed\n")
+            # print("Downloading Documents as JSON file\n")
+            # col.download_doc_as_json()
 
-        print("Selecting Index menu\n")
-        col.select_index_menu()
+            print("Filter collection by '_id'\n")
+            col.filter_documents(3)
+            col.filter_documents(1)
+            col.display_document_size(2)  # choosing 50 results to display
+            print("Traverse back and forth search result page 1 and 2\n")
+            col.traverse_search_pages()
+            print("Selecting hand selection button\n")
+            col.select_hand_pointer()
+            print("Select Multiple item using hand pointer\n")
+            col.select_multiple_item()
+            col.move_btn()
+            print("Multiple data moving into test collection\n")
+            col.move_doc_textbox("Test")
+            col.move_confirm_btn()
 
-        print("Create new index\n")
+            print("Deleting multiple data started\n")
+            col.select_multiple_item()
+            col.select_collection_delete_btn()
+            col.collection_delete_confirm_btn()
+            col.collection_really_dlt_btn()
+            print("Deleting multiple data completed\n")
 
-        version = col.current_package_version()
-        print(version, "\n")
-        print("Cluster status: ", self.is_cluster)
-        col.create_new_index("Persistent", 1, self.is_cluster)
-        col.create_new_index("Geo", 2, self.is_cluster)
-        col.create_new_index("Fulltext", 3, self.is_cluster)
-        col.create_new_index("TTL", 4, self.is_cluster)
-        if version >= semver.VersionInfo.parse("3.9.0"):
-            col.create_new_index("ZKD", 5, self.is_cluster)
-            print("Deleting all index started\n")
-            for _ in range(4):
-                col.delete_all_index()
-            print("Deleting all index completed\n")
-        else:
-            print("Deleting all index started\n")
-            for _ in range(3):
-                col.delete_all_index()
-            print("Deleting all index completed\n")
+            print("Selecting Index menu\n")
+            col.select_index_menu()
 
-        print("Select Info tab\n")
-        col.select_info_tab()
-        print("Selecting Schema Tab\n")
-        # col.select_schema_tab()
+            print("Create new index\n")
 
-        print("Select Settings tab\n")
-        col.select_settings_tab(self.is_cluster)
-        self.webdriver.refresh()
-        # some old bullshit
-        # print("Loading and Unloading collection\n")
-        # col.select_settings_unload_btn()
-        # col.select_settings_unload_btn()
-        self.webdriver.refresh()
-        print("Truncate collection\n")
-        col.select_truncate_btn()
-        self.webdriver.refresh()
-        # print("Deleting Collection started\n")
-        # col.delete_collection()
-        # #
-        # print("Selecting TestEdge Collection for deleting\n")
-        # col.select_edge_collection()
-        # col.delete_collection()
+            version = col.current_package_version()
+            print(version, "\n")
+            print("Cluster status: ", self.is_cluster)
+            col.create_new_index("Persistent", 1, self.is_cluster)
+            col.create_new_index("Geo", 2, self.is_cluster)
+            col.create_new_index("Fulltext", 3, self.is_cluster)
+            col.create_new_index("TTL", 4, self.is_cluster)
+            if version >= semver.VersionInfo.parse("3.9.0"):
+                col.create_new_index("ZKD", 5, self.is_cluster)
+                print("Deleting all index started\n")
+                for _ in range(4):
+                    col.delete_all_index()
+                print("Deleting all index completed\n")
+            else:
+                print("Deleting all index started\n")
+                for _ in range(3):
+                    col.delete_all_index()
+                print("Deleting all index completed\n")
 
-        # print("Selecting Test Collection for deleting\n")
-        # col.select_test_doc_collection()
-        # col.delete_collection()
-        # print("Deleting Collection completed\n")
+            print("Select Info tab\n")
+            col.select_info_tab()
+            print("Selecting Schema Tab\n")
+            # col.select_schema_tab()
 
-        # these will clearup the resources even in failed test case scenario
-        if self.is_cluster:
-            col.delete_collection("TestDoc", col.select_doc_collection_id)
-        else:
-            col.delete_collection("TestDocRenamed", col.select_renamed_doc_collection_id)
-        col.delete_collection("TestEdge", col.select_edge_collection_id)
-        col.delete_collection("Test", col.select_test_doc_collection_id)
+            print("Select Settings tab\n")
+            col.select_settings_tab(self.is_cluster)
+            self.webdriver.refresh()
+            # some old bullshit
+            # print("Loading and Unloading collection\n")
+            # col.select_settings_unload_btn()
+            # col.select_settings_unload_btn()
+            self.webdriver.refresh()
+            print("Truncate collection\n")
+            col.select_truncate_btn()
+            self.webdriver.refresh()
+            
+            
+            # print("Deleting Collection started\n")
+            # col.delete_collection()
+            # #
+            # print("Selecting TestEdge Collection for deleting\n")
+            # col.select_edge_collection()
+            # col.delete_collection()
 
-        del col
-        # login.logout_button()
-        # del login
-        print("---------Checking Collection Completed--------- \n")
+            # print("Selecting Test Collection for deleting\n")
+            # col.select_test_doc_collection()
+            # col.delete_collection()
+            # print("Deleting Collection completed\n")
+
+            # # these will clearup the resources even in failed test case scenario
+            # if self.is_cluster:
+            #     col.delete_collection("TestDoc", col.select_doc_collection_id)
+            # else:
+            #     col.delete_collection("TestDocRenamed", col.select_renamed_doc_collection_id)
+            # col.delete_collection("TestEdge", col.select_edge_collection_id)
+            # col.delete_collection("Test", col.select_test_doc_collection_id)
+
+
+
+            # login.logout_button()
+            # del login
+            print("---------Checking Collection Completed--------- \n")
+        
+        except BaseException:
+            print('x' * 45, "\nINFO: Error Occurred! Force cleanup started\n", 'x' * 45)
+            self.exception = True   # mark the exception as true
+            self.error = traceback.format_exc()
+        
+        finally:
+            # these will clearup the resources even in failed test case scenario
+            print("Collection deletion started \n")
+            col.delete_collection("TestDoc", col.select_doc_collection_id, self.is_cluster)          
+            col.delete_collection("TestDocRenamed", col.select_renamed_doc_collection_id, self.is_cluster)
+            col.delete_collection("TestEdge", col.select_edge_collection_id, self.is_cluster)
+            col.delete_collection("Test", col.select_test_doc_collection_id, self.is_cluster)
+            print("Deleting Collection completed\n")
+
+            if self.exception:
+                raise Exception(self.error)
+            del col

--- a/release_tester/selenium_ui_test/test_suites/collections_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/collections_test_suite.py
@@ -26,67 +26,6 @@ class CollectionsTestSuite(BaseSeleniumTestSuite):
         self.exception = False
         self.error = None
 
-        # print("Selecting collection tab\n")
-        # col.select_collection_page()
-
-        # print("Creating new collection started \n")
-        # col.select_create_collection()
-        # print("Creating Document collection \n")
-        # col.select_new_collection_name("TestDoc")
-        # print("Creating Document type collection started \n")
-        # col.select_collection_type(0)  # 0 for Doc type document
-
-        # if self.is_cluster:
-        #     print("Selecting number of shards for the current collection \n")
-        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
-
-        #     print("Selecting replication factor for the current collection \n")
-        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
-
-        # col.select_advance_option()
-        # print("Choosing wait type to YES \n")
-        # col.wait_for_sync(1)
-        # col.create_new_collection_btn()
-        # print("Creating Document type collection completed \n")
-
-        # print("Creating Edge type collection\n")
-        # col.select_create_collection()
-        # col.select_new_collection_name("TestEdge")
-        # col.select_collection_type(1)  # 1 for Edge type document
-
-        # if self.is_cluster:
-        #     print("Selecting number of shards for the current collection \n")
-        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
-
-        #     print("Selecting replication factor for the current collection \n")
-        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
-
-        # col.select_advance_option()
-        # print("Choosing wait type to YES \n")
-        # col.wait_for_sync(1)
-        # col.create_new_collection_btn()
-        # print("Creating new Edge collection completed \n")
-
-        # print("Creating new collection started \n")
-        # col.select_create_collection()
-        # print("Creating Document collection \n")
-        # col.select_new_collection_name("Test")
-        # print("Creating Document type collection started \n")
-        # col.select_collection_type(0)  # 0 for Doc type document
-
-        # if self.is_cluster:
-        #     print("Selecting number of shards for the current collection \n")
-        #     col.select_number_of_shards(9)  # it takes number of shards as an argument
-
-        #     print("Selecting replication factor for the current collection \n")
-        #     col.select_replication_factor(3)  # it takes number of replication factor as an argument
-
-        # col.select_advance_option()
-        # print("Choosing wait type to YES \n")
-        # col.wait_for_sync(1)
-        # col.create_new_collection_btn()
-        # print("Creating Document type collection completed \n")
-
         try:
             col.create_new_collections('TestDoc', 0, self.is_cluster)
             col.create_new_collections('TestEdge', 1, self.is_cluster)
@@ -218,32 +157,6 @@ class CollectionsTestSuite(BaseSeleniumTestSuite):
             print("Truncate collection\n")
             col.select_truncate_btn()
             self.webdriver.refresh()
-            
-            
-            # print("Deleting Collection started\n")
-            # col.delete_collection()
-            # #
-            # print("Selecting TestEdge Collection for deleting\n")
-            # col.select_edge_collection()
-            # col.delete_collection()
-
-            # print("Selecting Test Collection for deleting\n")
-            # col.select_test_doc_collection()
-            # col.delete_collection()
-            # print("Deleting Collection completed\n")
-
-            # # these will clearup the resources even in failed test case scenario
-            # if self.is_cluster:
-            #     col.delete_collection("TestDoc", col.select_doc_collection_id)
-            # else:
-            #     col.delete_collection("TestDocRenamed", col.select_renamed_doc_collection_id)
-            # col.delete_collection("TestEdge", col.select_edge_collection_id)
-            # col.delete_collection("Test", col.select_test_doc_collection_id)
-
-
-
-            # login.logout_button()
-            # del login
             print("---------Checking Collection Completed--------- \n")
         
         except BaseException:


### PR DESCRIPTION
With this PR, we would like to add a feature that will force delete any created collection, views, or analyzer in case of UI test failure before it actually gets to the point where it deletes those resources. This will ensure the deletion of test-related created data in case of failure in order to maintain the overall test integrity for Check data. 