### PR TITLE
re-add test

### DIFF
--- a/test_data/makedata_suites/560_smartgraph_edge_validator.js
+++ b/test_data/makedata_suites/560_smartgraph_edge_validator.js
@@ -1,0 +1,59 @@
+/* global fs, PWD, writeGraphData, getShardCount, getReplicationFactor,  print, progress, db, createSafe, _, semver */
+
+(function () {
+  return {
+    isSupported: function (currentVersion, oldVersion, options, enterprise, cluster) {
+      let current = semver.parse(semver.coerce(currentVersion));
+
+      return semver.gte(current, "3.9.0") && cluster && !options.readOnly;
+    },
+    checkData: function (options, isCluster, isEnterprise, dbCount, loopCount, readOnly) {
+      // depends on the 550_enterprise_graph.js to be there
+      print(`checking data ${dbCount} ${loopCount}`);
+      const ArangoError = require('@arangodb').ArangoError;
+
+      try {
+        const vColName = `patents_smart_${loopCount}`;
+        const eColName = `citations_smart_${loopCount}`;
+        const gName = `G_smart_${loopCount}`;
+        const remoteDocument = {
+          _key: "abc:123:def",
+          _from: `${vColName}/abc:123`,
+          _to: `${vColName}/def:123`
+        };
+        const localDocument = {
+          _key: "abc:123:abc",
+          _from: `${vColName}/abc:123`,
+          _to: `${vColName}/abc:123`
+        };
+        const testValidator = (colName, doc) => {
+          let col = db._collection(colName);
+          if (!col) {
+            throw new Error(`The smartGraph "${gName}" was not created correctly, collection ${colName} missing`);
+          }
+          try {
+            col.save(doc);
+            throw new Error(`Validator did not trigger on collection ${colName} stored illegal document`);
+          } catch (e) {
+            // We only allow the following two errors, all others should be reported.
+            if (e instanceof ArangoError) {
+              if (e.errorNum !== 1466 &&
+                  e.errorNum !== 1233) {
+                throw new Error(`Validator of collection ${colName} on atempt to store ${doc} returned unexpected error: ${e.errorNum} - ${e.message}`)
+              }
+            } else {
+              throw(e);
+            }
+          }
+        };
+        // We try to insert a document into the wrong shard. This should be rejected by the internal validator
+        testValidator(`_local_${eColName}`, remoteDocument);
+        testValidator(`_from_${eColName}`, localDocument);
+        testValidator(`_to_${eColName}`, localDocument);
+      } finally {
+        // Always report that we tested SmartGraph edge Validators
+        progress("Tested SmartGraph edge validators");
+      }
+    }
+  };
+}());

--- a/test_data/makedata_suites/561_smartgraph_vertex_validator.js
+++ b/test_data/makedata_suites/561_smartgraph_vertex_validator.js
@@ -1,0 +1,49 @@
+/* global fs, PWD, writeGraphData, getShardCount, getReplicationFactor,  print, progress, db, createSafe, _, semver */
+
+(function () {
+  return {
+    isSupported: function (currentVersion, oldVersion, options, enterprise, cluster) {
+      let current = semver.parse(semver.coerce(currentVersion));
+      return semver.gte(current, "3.10.0") && cluster && !options.readOnly;
+    },
+    checkData: function (options, isCluster, isEnterprise, dbCount, loopCount, readOnly) {
+      // depends on the 550_enterprise_graph.js to be there
+      const ArangoError = require('@arangodb').ArangoError;
+      print(`checking data ${dbCount} ${loopCount}`);
+      try {
+        const vColName = `patents_smart_${ccount}`;
+        const gName = `G_smart_${ccount}`;
+        const mismatchedSGAPrefixDoc = {_key: 'NL:1', COUNTRY: 'DE'}
+        const missingSGAPrefixDoc = {_key: '1', COUNTRY: 'DE'}
+
+        const vCol = db._collection(vColName);
+        if (!vCol) {
+          throw new Error(`The smartGraph "${gName}" was not created correctly, collection ${vColName} missing`)
+        }
+
+        const testValidator = doc => {
+          try {
+            vCol.save(doc);
+            throw new Error(`Validator did not trigger on collection ${vColName} stored illegal document`);
+          } catch (e) {
+            // We only allow the following two errors, all others should be reported.
+            if (e instanceof ArangoError) {
+              if (e.errorNum !== 4003 && e.errorNum !== 4001) {
+                throw new Error(`Validator of collection ${colName} on atempt to store ${doc} returned unexpected error: ${e.errorNum} - ${e.message}`)
+              }
+            } else {
+              throw(e);
+            }
+          }
+        }
+
+        // We try to insert a document with the wrong key. This should be rejected by the internal validator.
+        testValidator(mismatchedSGAPrefixDoc);
+        testValidator(missingSGAPrefixDoc);
+      } finally {
+        // Always report that we tested SmartGraph vertex Validators
+        progress("Tested SmartGraph vertex validators");
+      }
+    }
+  };
+}());


### PR DESCRIPTION
re-create reverted https://github.com/arangodb/release-test-automation/pull/203 :
Adds a test for SmartVertex schema validator, which will be introduced in 3.10.0.

**Note:**
This PR can only be merged AFTER the following PRs are merged into `devel`. Otherwise we expect 3.9.* -> 3.10.* Jenkins run to always fail.

https://github.com/arangodb/arangodb/pull/15090
https://github.com/arangodb/enterprise/pull/798


Related BTS Ticket: https://arangodb.atlassian.net/browse/BTS-663

