### PR TITLE
re-enable test after the enterprise-graph implementation was fixed

### DIFF
--- a/test_data/makedata_suites/570_enterprise_graph.js
+++ b/test_data/makedata_suites/570_enterprise_graph.js
@@ -7,7 +7,6 @@
 
   return {
     isSupported: function (currentVersion, oldVersion, options, enterprise, cluster) {
-      return false; // this test is known to be broken.
       // strip off -nightly etc:
       let ver = semver.parse(oldVersion.split('-')[0]);
       return enterprise && (semver.gte(ver, "3.10.0"));

--- a/test_data/makedata_suites/950_read_from_follower.js
+++ b/test_data/makedata_suites/950_read_from_follower.js
@@ -587,7 +587,6 @@ let restoreServerLoggingSettings = function (topic) {
         }
       }
 
-      return 0;
       databaseName = `${baseName}_${dbCount}_entGraph`;
       db._useDatabase(databaseName);
       jsunity.run(ReadSmartGraphFromFollowerTestSuite(`citations_enterprise_${dbCount}`, `patents_enterprise_${dbCount}`, databaseName));


### PR DESCRIPTION
merge once BTS-1195 is fixed.