### PR TITLE
disable license manager tests if exteral helpers are not present(for community edition)

### DIFF
--- a/release_tester/license_manager_tests/basic_test_suite.py
+++ b/release_tester/license_manager_tests/basic_test_suite.py
@@ -3,16 +3,18 @@
 import platform
 
 from license_manager_tests.afo import LicenseManagerAfoTestSuite
-from license_manager_tests.base.license_manager_base_test_suite import LicenseManagerBaseTestSuite
+from license_manager_tests.base.license_manager_base_test_suite import LicenseManagerBaseTestSuite, \
+    EXTERNAL_HELPERS_LOADED
 from license_manager_tests.cluster import LicenseManagerClusterTestSuite
 from license_manager_tests.dc2dc import LicenseManagerDc2DcTestSuite
 from license_manager_tests.leader_follower import LicenseManagerLeaderFollowerTestSuite
 from license_manager_tests.single_server import LicenseManagerSingleServerTestSuite
-from test_suites_core.base_test_suite import run_before_suite, run_after_suite
+from test_suites_core.base_test_suite import run_before_suite, run_after_suite, disable_if_false
 
 IS_WINDOWS = platform.win32_ver()[0] != ""
 
 
+@disable_if_false(EXTERNAL_HELPERS_LOADED, "External helpers not found. License manager tests will not run.")
 class BasicLicenseManagerTestSuite(LicenseManagerBaseTestSuite):
     """License manager test suite: Clean installation"""
 

--- a/release_tester/license_manager_tests/upgrade/upgrade_test_suite.py
+++ b/release_tester/license_manager_tests/upgrade/upgrade_test_suite.py
@@ -2,16 +2,19 @@
 """License manager test suite(upgrade)"""
 import platform
 
-from license_manager_tests.base.license_manager_base_test_suite import LicenseManagerBaseTestSuite
+from license_manager_tests.base.license_manager_base_test_suite import LicenseManagerBaseTestSuite, \
+    EXTERNAL_HELPERS_LOADED
 from license_manager_tests.upgrade.afo import LicenseManagerAfoUpgradeTestSuite
 from license_manager_tests.upgrade.cluster import LicenseManagerClusterUpgradeTestSuite
 from license_manager_tests.upgrade.dc2dc import LicenseManagerDc2DcUpgradeTestSuite
 from license_manager_tests.upgrade.leader_follower import LicenseManagerLeaderFollowerUpgradeTestSuite
 from license_manager_tests.upgrade.single_server import LicenseManagerSingleServerUpgradeTestSuite
+from test_suites_core.base_test_suite import disable_if_false
 
 IS_WINDOWS = platform.win32_ver()[0] != ""
 
 
+@disable_if_false(EXTERNAL_HELPERS_LOADED, "External helpers not found. License manager tests will not run.")
 class UpgradeLicenseManagerTestSuite(LicenseManagerBaseTestSuite):
     """License manager test suite: Upgrade"""
 

--- a/release_tester/test_suites_core/base_test_suite.py
+++ b/release_tester/test_suites_core/base_test_suite.py
@@ -354,6 +354,10 @@ def disable_if_true(value, reason=None):
     return set_disable_reason
 
 
+def disable_if_false(value, reason=None):
+    return disable_if_true(not value, reason)
+
+
 def disable_if_returns_true_at_runtime(function, reason=None):
     def set_disable_func_and_reason(testcase_func):
         testcase_func.disable_functions.append((function, reason))


### PR DESCRIPTION
…community runs)