### PR TITLE
added unipath to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,5 @@ docker; platform_system == "Linux"
 py7zr
 paramiko
 scp
+unipath
 pre-commit


### PR DESCRIPTION
Ansible pulles the requirements.txt to install all needed python modules via pip. Vadim found out that for Linux the unipath module was missing