### PR TITLE
Optimize agency leader detection algorithm

### DIFF
--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -986,14 +986,11 @@ class Runner(ABC):
     @step
     def agency_get_leader_starter_instance(self):
         """get the starter instance that manages the current agency leader"""
-        agency = []
-        for starter_mgr in self.starter_instances:
-            agency += starter_mgr.get_agents()
         leader = None
         leading_date = datetime.datetime(1970, 1, 1, 0, 0, 0)
         for starter_mgr in self.starter_instances:
-            agency = starter_mgr.get_agents()
-            for agent in agency:
+            agents = starter_mgr.get_agents()
+            for agent in agents:
                 agent_leading_date = agent.search_for_agent_serving()
                 if agent_leading_date > leading_date:
                     leading_date = agent_leading_date


### PR DESCRIPTION
Optimize agency leader detection algorithm.
Now we detect leader by searching for a string that is emitted when an agent becomes a leader. Timestamps from such strings from different agents' log files are compared. The one which has the latest timestamp is considered current leader. But sometimes leader can be changed several times in a row rapidly. In this case, two agents might have identical timestamps. To fix this, additionally we are looking for another string, which says that the agent became a follower. If this string is found after the "leader" string, the latter is ignored.
+lint