### PR TITLE
proper logfile parsing on shutdown

### DIFF
--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -369,10 +369,11 @@ please revalidate the UI states on the new leader; you should see *one* follower
             self.selenium.test_wait_for_upgrade()
 
     def shutdown_impl(self):
+        ret = False
         for node in self.starter_instances:
-            node.terminate_instance()
-
+            ret = ret or node.terminate_instance()
         logging.info("test ended")
+        return ret
 
     def before_backup_create_impl(self):
         pass

--- a/release_tester/arangodb/starter/deployments/cluster.py
+++ b/release_tester/arangodb/starter/deployments/cluster.py
@@ -437,9 +437,11 @@ db.testCollection.save({test: "document"})
             self.selenium.jam_step_2()
 
     def shutdown_impl(self):
+        ret = False
         for node in self.starter_instances:
-            node.terminate_instance()
+            ret = ret or node.terminate_instance()
         logging.info("test ended")
+        return ret
 
     def before_backup_impl(self):
         pass

--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -657,8 +657,8 @@ class Dc2Dc(Runner):
         self._get_in_sync(20)
 
     def shutdown_impl(self):
-        self.cluster1["instance"].terminate_instance()
-        self.cluster2["instance"].terminate_instance()
+        return (self.cluster1["instance"].terminate_instance() or
+                self.cluster2["instance"].terminate_instance())
 
     def before_backup_create_impl(self):
         pass

--- a/release_tester/arangodb/starter/deployments/leaderfollower.py
+++ b/release_tester/arangodb/starter/deployments/leaderfollower.py
@@ -348,12 +348,13 @@ process.exit(0);
 
     @step
     def shutdown_impl(self):
-        self.leader_starter_instance.terminate_instance()
-        self.follower_starter_instance.terminate_instance()
+        ret = (self.leader_starter_instance.terminate_instance() or
+               self.follower_starter_instance.terminate_instance())
         pslist = get_all_processes(False)
         if len(pslist) > 0:
             raise Exception("Not all processes terminated! [%s]" % str(pslist))
         logging.info("test ended")
+        return ret
 
     def before_backup_impl(self):
         pass

--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -646,8 +646,7 @@ class Runner(ABC):
     def starter_shutdown(self):
         """stop everything"""
         self.progress(True, "{0}{1} - shutdown".format(self.versionstr, str(self.name)))
-        warnings_found  = self.search_for_warnings()
-        self.shutdown_impl()
+        warnings_found = self.shutdown_impl()
         if warnings_found:
             raise Exception("warnings found during shutdown")
 

--- a/release_tester/arangodb/starter/deployments/single.py
+++ b/release_tester/arangodb/starter/deployments/single.py
@@ -159,11 +159,12 @@ class Single(Runner):
 
     @step
     def shutdown_impl(self):
-        self.starter_instance.terminate_instance()
+        ret = self.starter_instance.terminate_instance()
         pslist = get_all_processes(False)
         if len(pslist) > 0:
             raise Exception("Not all processes terminated! [%s]" % str(pslist))
         logging.info("test ended")
+        return ret
 
     def before_backup_create_impl(self):
         pass

--- a/release_tester/arangodb/starter/manager.py
+++ b/release_tester/arangodb/starter/manager.py
@@ -606,7 +606,7 @@ class StarterManager:
         ret = False
         for instance in self.all_instances:
             print("u" * 80)
-            if instance.search_for_warnings(print_lines):
+            if instance.search_for_warnings(True):
                 ret = True
         self.is_leader = False
         self.all_instances = []

--- a/release_tester/arangodb/starter/manager.py
+++ b/release_tester/arangodb/starter/manager.py
@@ -149,7 +149,7 @@ class StarterManager:
                     self.expect_instance_count += 2  # syncmaster + syncworker
 
         semversion = semver.VersionInfo.parse(self.cfg.version)
-        self.supportsExtendedNames = (semversion.major == 3 and semversion.minor >= 9) or (semversion.major > 3)
+        self.supports_extended_names = (semversion.major == 3 and semversion.minor >= 9) or (semversion.major > 3)
         self.username = "root"
         self.passvoid = ""
 
@@ -199,7 +199,7 @@ class StarterManager:
         semversion = semver.VersionInfo.parse(version)
 
         # Extended database names were introduced in 3.9.0
-        if self.supportsExtendedNames:
+        if self.supports_extended_names:
             result += ["--args.all.database.extended-names-databases=true"]
 
         # Telemetry was introduced in 3.11.0
@@ -600,11 +600,17 @@ class StarterManager:
             for i in self.all_instances:
                 i.pid = None
                 i.ppid = None
-        else:
-            # Clear instances as they have been stopped and the logfiles
-            # have been moved.
-            self.is_leader = False
-            self.all_instances = []
+            return False
+        # Clear instances as they have been stopped and the logfiles
+        # have been moved.
+        ret = False
+        for instance in self.all_instances:
+            print("u" * 80)
+            if instance.search_for_warnings(print_lines):
+                ret = True
+        self.is_leader = False
+        self.all_instances = []
+        return ret
 
     @step
     def kill_instance(self):

--- a/release_tester/test_driver.py
+++ b/release_tester/test_driver.py
@@ -269,8 +269,6 @@ class TestDriver:
                             if runner:
                                 try:
                                     runner.run()
-                                    if runner.search_for_warnings(False):
-                                        raise Exception("fatal log lines found")
                                     runner.cleanup()
                                     testcase.context.status = Status.PASSED
                                 except Exception as ex:
@@ -433,8 +431,6 @@ class TestDriver:
 
                     try:
                         runner.run()
-                        if runner.search_for_warnings(False):
-                            raise Exception("fatal log lines found")
                         runner.cleanup()
                         testcase.context.status = Status.PASSED
                     # pylint: disable=broad-except
@@ -561,8 +557,6 @@ class TestDriver:
                     "messages": [],
                     "progress": "",
                 })
-            if runner.search_for_warnings(False):
-                raise Exception("fatal log lines found")
         except Exception as ex:
             failed = True
             print("".join(traceback.TracebackException.from_exception(ex).format()))


### PR DESCRIPTION
The tests would make the starter manager flush its intance objects; hence we need to search for warnings  via them right before this happenes. 
Remove unneccessary invocations. 