### PR TITLE
try not to download enterprise packages twice

### DIFF
--- a/release_tester/arangodb/installers/__init__.py
+++ b/release_tester/arangodb/installers/__init__.py
@@ -465,6 +465,7 @@ class RunProperties:
     def __init__(
         self,
         enterprise: bool,
+        force_dl: bool = True,
         encryption_at_rest: bool = False,
         ssl: bool = False,
         replication2: bool = False,
@@ -473,6 +474,7 @@ class RunProperties:
     ):
         """set the values for this testrun"""
         self.enterprise = enterprise
+        self.force_dl = force_dl
         self.encryption_at_rest = encryption_at_rest
         self.ssl = ssl
         self.testrun_name = testrun_name
@@ -503,9 +505,9 @@ directory_suffix: {0.directory_suffix}""".format(
 
 # pylint: disable=too-many-function-args
 EXECUTION_PLAN = [
-    RunProperties(True, True, True, False, "Enterprise\nEnc@REST", "EE"),
-    RunProperties(True, False, False, False, "Enterprise", "EP"),
-    RunProperties(False, False, False, False, "Community", "C"),
+    RunProperties(True, True, True, True, False, "Enterprise\nEnc@REST", "EE"),
+    RunProperties(True, False, False, False, False, "Enterprise", "EP"),
+    RunProperties(False, True,  False, False, False, "Community", "C"),
 ]
 
 

--- a/release_tester/full_download_test.py
+++ b/release_tester/full_download_test.py
@@ -54,8 +54,10 @@ def package_test(
         props.replication2 = replication2
         if props.directory_suffix not in editions:
             continue
+        dl_opt = deepcopy(dl_opts)
+        dl_opt.force_dl = dl_opts.force_dl and props.force_dl
         dl_new = Download(
-            dl_opts,
+            dl_opt,
             test_driver.base_config.hb_cli_cfg,
             new_version,
             props.enterprise,

--- a/release_tester/full_download_upgrade.py
+++ b/release_tester/full_download_upgrade.py
@@ -43,8 +43,10 @@ def upgrade_package_test(
         if props.directory_suffix not in editions:
             continue
         # pylint: disable=unused-variable
+        dl_opt = deepcopy(dl_opts)
+        dl_opt.force_dl = dl_opts.force_dl and props.force_dl
         dl_old = Download(
-            dl_opts,
+            dl_opt,
             test_driver.base_config.hb_cli_cfg,
             old_version,
             props.enterprise,
@@ -56,7 +58,7 @@ def upgrade_package_test(
             git_version,
         )
         dl_new = Download(
-            dl_opts,
+            dl_opt,
             test_driver.base_config.hb_cli_cfg,
             new_version,
             props.enterprise,

--- a/release_tester/full_download_upgrade_test.py
+++ b/release_tester/full_download_upgrade_test.py
@@ -65,11 +65,13 @@ def upgrade_package_test(
                 props = copy(default_props)
                 if props.directory_suffix not in editions:
                     continue
+                dl_opt = deepcopy(dl_opts)
+                dl_opt.force_dl = dl_opts.force_dl and props.force_dl
                 props.testrun_name = "test_" + props.testrun_name
                 # Verify that all required packages are exist or can be downloaded
                 source = primary_dlstage if primary_version == version_name else other_source
                 res = Download(
-                    dl_opts,
+                    dl_opt,
                     test_driver.base_config.hb_cli_cfg,
                     version_name,
                     props.enterprise,

--- a/release_tester/test.py
+++ b/release_tester/test.py
@@ -48,7 +48,7 @@ def main(**kwargs):
             kwargs["starter_mode"],
             [semver.VersionInfo.parse(kwargs["new_version"])],
             # pylint: disable=too-many-function-args
-            RunProperties(kwargs["enterprise"], kwargs["encryption_at_rest"], kwargs["ssl"], kwargs["replication2"]),
+            RunProperties(kwargs["enterprise"], True, kwargs["encryption_at_rest"], kwargs["ssl"], kwargs["replication2"]),
         )
         print("V" * 80)
         status = True

--- a/release_tester/test_driver.py
+++ b/release_tester/test_driver.py
@@ -151,7 +151,7 @@ class TestDriver:
         if self.installer_type:
             return self.installer_type
         installers = create_config_installer_set(
-            ["3.3.3"], self.base_config, "all", RunProperties(False, False, False), False
+            ["3.3.3"], self.base_config, "all", RunProperties(False, False, False, False), False
         )
         self.installer_type = installers[0][1].installer_type.split(" ")[0].replace(".", "")
         return self.installer_type


### PR DESCRIPTION
as seen in https://jenkins01.arangodb.biz/job/Upgrade-3.9-to-3.10.Windows/1111/LIMIT=windows&&test&&rta,PACKAGE=EXE/consoleFull  we seem to download the  enterprise packages twice. Try to avoid that to save  resources. 