### PR TITLE
Limit syncworker concurrency during initial-sync phase

### DIFF
--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -202,7 +202,7 @@ class Dc2Dc(Runner):
                     # '--all.log.level=requests=debug',
                     '--args.syncmasters.log.level=debug',
                     '--args.syncworkers.log.level=debug',
-                    '--args.syncworkers.worker.max-initial-sync-tasks=8', # limit concurrency during initial-sync phase (default 16)
+                    '--args.syncworkers.worker.max-initial-sync-tasks=8', # FIXME: temp solution for BTS-1690 - limit concurrency during initial-sync phase (default 16)
                     '--args.sync.log.stderr=false',
                     '--starter.sync',
                     '--starter.local',

--- a/release_tester/arangodb/starter/deployments/dc2dc.py
+++ b/release_tester/arangodb/starter/deployments/dc2dc.py
@@ -202,6 +202,7 @@ class Dc2Dc(Runner):
                     # '--all.log.level=requests=debug',
                     '--args.syncmasters.log.level=debug',
                     '--args.syncworkers.log.level=debug',
+                    '--args.syncworkers.worker.max-initial-sync-tasks=8', # limit concurrency during initial-sync phase (default 16)
                     '--args.sync.log.stderr=false',
                     '--starter.sync',
                     '--starter.local',


### PR DESCRIPTION
That should make test env more stable