### PR TITLE
add tests to check that --version output contains license information

### DIFF
--- a/release_tester/arangodb/installers/base.py
+++ b/release_tester/arangodb/installers/base.py
@@ -82,8 +82,7 @@ class InstallerBase(ABC):
         eps = "E_" if self.cfg.enterprise else ""
         self.backup_arangod_name = self.cfg.base_test_dir / f"arangod_{eps}_{self.cfg.version}{FILE_EXTENSION}"
         arangod_src = self.cfg.real_sbin_dir / f"arangod{FILE_EXTENSION}"
-        if (not str(self.backup_arangod_name) in self.arangods and
-            arangod_src.exists()):
+        if not str(self.backup_arangod_name) in self.arangods and arangod_src.exists():
             self.arangods.append(self.backup_arangod_name)
             print("copying " + str(arangod_src) + " to " + str(self.backup_arangod_name))
             shutil.copy(str(arangod_src), str(self.backup_arangod_name))
@@ -428,7 +427,7 @@ class InstallerBase(ABC):
                 BinaryDescription(
                     self.cfg.real_bin_dir,
                     "arangobench",
-                    "arangobench.*", #  - stress test tool",
+                    "arangobench.*",  #  - stress test tool",
                     False,
                     True,
                     "1.0.0",
@@ -473,7 +472,7 @@ class InstallerBase(ABC):
                 BinaryDescription(
                     self.cfg.real_sbin_dir,
                     "arangod",
-                     "ArangoDB - the native multi-model NoSQL database",
+                    "ArangoDB - the native multi-model NoSQL database",
                     False,
                     stripped_arangod,
                     "1.0.0",
@@ -553,7 +552,7 @@ class InstallerBase(ABC):
         for binary in self.arango_binaries:
             progress("S" if binary.stripped else "s")
             binary.check_installed(
-                self.semver, self.cfg.enterprise, self.check_stripped, self.check_symlink, self.check_notarized
+                self.semver, self.cfg.enterprise, self.check_stripped, self.check_symlink, self.check_notarized, False
             )
         print("\nran file commands with PID:" + str(FILE_PIDS) + "\n")
         FILE_PIDS = []
@@ -577,7 +576,7 @@ class InstallerBase(ABC):
         return success
 
     def get_log_dir(self):
-        """ get the directory the installer will create logs in """
+        """get the directory the installer will create logs in"""
         return self.cfg.install_prefix / self.cfg.log_dir
 
     def set_system_instance(self):
@@ -653,8 +652,7 @@ class InstallerBase(ABC):
 
     def get_sync_version(self):
         """find out the version of the starter in this package"""
-        if (not self.cfg.enterprise or
-            self.semver > semver.VersionInfo.parse("3.11.99")):
+        if not self.cfg.enterprise or self.semver > semver.VersionInfo.parse("3.11.99"):
             return semver.VersionInfo.parse("0.0.0")
         if not self.syncer_versions:
             syncer = self.cfg.real_sbin_dir / ("arangosync" + FILE_EXTENSION)

--- a/release_tester/full_download_test.py
+++ b/release_tester/full_download_test.py
@@ -93,7 +93,7 @@ def package_test(
             params.enterprise = True
             results.append(
                 test_driver.run_test_suites(
-                    include_suites=("DebuggerTestSuite", "BasicLicenseManagerTestSuite"),
+                    include_suites=("DebuggerTestSuite", "BasicLicenseManagerTestSuite", "BinaryComplianceTestSuite",),
                     params=params,
                 )
             )
@@ -101,7 +101,7 @@ def package_test(
             params.enterprise = False
             results.append(
                 test_driver.run_test_suites(
-                    include_suites=("DebuggerTestSuite",),
+                    include_suites=("DebuggerTestSuite", "BinaryComplianceTestSuite",),
                     params=params,
                 )
             )

--- a/release_tester/full_download_upgrade.py
+++ b/release_tester/full_download_upgrade.py
@@ -124,7 +124,7 @@ def upgrade_package_test(
         params.enterprise = True
         results.append(
             test_driver.run_test_suites(
-                include_suites=("DebuggerTestSuite", "BasicLicenseManagerTestSuite", "UpgradeLicenseManagerTestSuite"),
+                include_suites=("DebuggerTestSuite", "BasicLicenseManagerTestSuite", "UpgradeLicenseManagerTestSuite", "BinaryComplianceTestSuite"),
                 params=params,
             )
         )
@@ -133,7 +133,7 @@ def upgrade_package_test(
         params.enterprise = False
         results.append(
             test_driver.run_test_suites(
-                include_suites=("DebuggerTestSuite",),
+                include_suites=("DebuggerTestSuite", "BinaryComplianceTestSuite",),
                 params=params,
             )
         )

--- a/release_tester/full_download_upgrade_test.py
+++ b/release_tester/full_download_upgrade_test.py
@@ -188,6 +188,7 @@ def upgrade_package_test(
                             "DebuggerTestSuite",
                             "BasicLicenseManagerTestSuite",
                             "UpgradeLicenseManagerTestSuite",
+                            "BinaryComplianceTestSuite",
                         ),
                         params=params,
                     )
@@ -197,7 +198,10 @@ def upgrade_package_test(
                 params.enterprise = False
                 results.append(
                     test_driver.run_test_suites(
-                        include_suites=("DebuggerTestSuite",),
+                        include_suites=(
+                            "DebuggerTestSuite",
+                            "BinaryComplianceTestSuite",
+                        ),
                         params=params,
                     )
                 )

--- a/release_tester/mixed_download_upgrade_test.py
+++ b/release_tester/mixed_download_upgrade_test.py
@@ -262,6 +262,7 @@ def upgrade_package_test(
                             "DebuggerTestSuite",
                             "BasicLicenseManagerTestSuite",
                             "UpgradeLicenseManagerTestSuite",
+                            "BinaryComplianceTestSuite",
                         ),
                         params=params,
                     )
@@ -271,7 +272,7 @@ def upgrade_package_test(
                 params.enterprise = False
                 results.append(
                     test_driver.run_test_suites(
-                        include_suites=("DebuggerTestSuite",),
+                        include_suites=("DebuggerTestSuite", "BinaryComplianceTestSuite",),
                         params=params,
                     )
                 )

--- a/release_tester/test_driver.py
+++ b/release_tester/test_driver.py
@@ -29,6 +29,7 @@ from package_installation_tests.enterprise_package_installation_test_suite impor
 from reporting.reporting_utils import RtaTestcase, AllureTestSuiteContext, init_allure
 from reporting.reporting_utils2 import generate_suite_name
 from siteconfig import SiteConfig
+from test_suites.misc.binary_test_suite import BinaryComplianceTestSuite
 from test_suites_core.cli_test_suite import CliTestSuiteParameters
 from overload_thread import spawn_overload_watcher_thread, shutdown_overload_watcher_thread
 
@@ -53,6 +54,7 @@ FULL_TEST_SUITE_LIST = [
     BasicLicenseManagerTestSuite,
     UpgradeLicenseManagerTestSuite,
     DebuggerTestSuite,
+    BinaryComplianceTestSuite,
 ]
 
 

--- a/release_tester/test_suites/misc/binary_test_suite.py
+++ b/release_tester/test_suites/misc/binary_test_suite.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""this test suite is intended to perform all checks of the binary files, e.g. stripping, signatures etc."""
+import semver
+
+from arangodb.installers import create_config_installer_set
+from reporting.reporting_utils import step
+from test_suites_core.base_test_suite import parameters, testcase, run_after_each_testcase, run_before_suite
+from test_suites_core.cli_test_suite import CliStartedTestSuite, CliTestSuiteParameters
+
+
+class BinaryComplianceTestSuite(CliStartedTestSuite):
+    def __init__(self, params: CliTestSuiteParameters):
+        min_version = semver.VersionInfo.parse("3.12.0-nightly")
+        super().__init__(params)
+        if (
+            self.new_version is not None
+            and semver.VersionInfo.parse(self.new_version) < min_version
+        ):
+            self.__class__.is_disabled = True
+            # pylint: disable=no-member
+            self.__class__.disable_reasons.append(
+                "Test suite is only applicable to versions 3.12 and newer."
+            )
+        self.installer_set = create_config_installer_set(
+            versions=[self.new_version],
+            base_config=self.base_cfg,
+            deployment_mode="all",
+            run_properties=self.run_props,
+            use_auto_certs=False,
+        )
+        self.installer = self.installer_set[0][1]
+        ent = "Enterprise" if self.run_props.enterprise else "Community"
+        self.suite_name = f"Binary compliance test suite: ArangoDB v. {str(self.new_version)} ({ent}) ({self.installer.installer_type})"
+        self.binary_file_names = [
+            "arangobackup",
+            "arangobench",
+            "arangodump",
+            "arangoexport",
+            "arangoimport",
+            "arangorestore",
+            "arangosh",
+            "arangovpack",
+            "arangod",
+        ]
+
+    @run_after_each_testcase
+    def uninstall_everything(self):
+        """uninstall all packages"""
+        self.installer.un_install_server_package()
+        self.installer.un_install_client_package()
+        self.installer.uninstall_everything()
+        self.installer.cleanup_system()
+        self.installer.cfg.server_package_is_installed = False
+        self.installer.cfg.client_package_is_installed = False
+
+    @testcase("Check that --version output contains information required by third party libraries(server package)")
+    def test_license_info_server_package(self):
+        self.installer.install_server_package()
+        self.installer.stop_service()
+        binaries = [file for file in self.installer.arango_binaries if file.path.name in self.binary_file_names]
+        for bin in binaries:
+            with step(f"check {bin.name}"):
+                bin.check_license_info()
+
+    @testcase("Check that --version output contains information required by third party libraries(client package)")
+    def test_license_info_client_package(self):
+        self.installer.install_client_package()
+        binaries = [file for file in self.installer.arango_binaries if file.path.name in self.binary_file_names]
+        for bin in binaries:
+            with step(f"check {bin.name}"):
+                bin.check_license_info()

--- a/release_tester/test_suites/misc/binary_test_suite.py
+++ b/release_tester/test_suites/misc/binary_test_suite.py
@@ -26,17 +26,6 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
         self.installer = self.installer_set[0][1]
         ent = "Enterprise" if self.run_props.enterprise else "Community"
         self.suite_name = f"Binary compliance test suite: ArangoDB v. {str(self.new_version)} ({ent}) ({self.installer.installer_type})"
-        self.binary_file_names = [
-            "arangobackup",
-            "arangobench",
-            "arangodump",
-            "arangoexport",
-            "arangoimport",
-            "arangorestore",
-            "arangosh",
-            "arangovpack",
-            "arangod",
-        ]
 
     @run_after_each_testcase
     def uninstall_everything(self):
@@ -55,7 +44,7 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
         binaries = [
             file
             for file in self.installer.arango_binaries
-            if file.path.name in self.binary_file_names and not (not self.run_props.enterprise and file.enterprise)
+            if file.binary_type=="c++" and not (not self.run_props.enterprise and file.enterprise)
         ]
         for bin in binaries:
             with step(f"check {bin.name}"):
@@ -67,7 +56,7 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
         binaries = [
             file
             for file in self.installer.arango_binaries
-            if file.path.name in self.binary_file_names and not (not self.run_props.enterprise and file.enterprise)
+            if file.binary_type=="c++" and not (not self.run_props.enterprise and file.enterprise)
         ]
         for bin in binaries:
             with step(f"check {bin.name}"):

--- a/release_tester/test_suites/misc/binary_test_suite.py
+++ b/release_tester/test_suites/misc/binary_test_suite.py
@@ -12,15 +12,10 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
     def __init__(self, params: CliTestSuiteParameters):
         min_version = semver.VersionInfo.parse("3.12.0-nightly")
         super().__init__(params)
-        if (
-            self.new_version is not None
-            and semver.VersionInfo.parse(self.new_version) < min_version
-        ):
+        if self.new_version is not None and semver.VersionInfo.parse(self.new_version) < min_version:
             self.__class__.is_disabled = True
             # pylint: disable=no-member
-            self.__class__.disable_reasons.append(
-                "Test suite is only applicable to versions 3.12 and newer."
-            )
+            self.__class__.disable_reasons.append("Test suite is only applicable to versions 3.12 and newer.")
         self.installer_set = create_config_installer_set(
             versions=[self.new_version],
             base_config=self.base_cfg,
@@ -57,7 +52,11 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
     def test_license_info_server_package(self):
         self.installer.install_server_package()
         self.installer.stop_service()
-        binaries = [file for file in self.installer.arango_binaries if file.path.name in self.binary_file_names]
+        binaries = [
+            file
+            for file in self.installer.arango_binaries
+            if file.path.name in self.binary_file_names and not (not self.run_props.enterprise and file.enterprise)
+        ]
         for bin in binaries:
             with step(f"check {bin.name}"):
                 bin.check_license_info()
@@ -65,7 +64,11 @@ class BinaryComplianceTestSuite(CliStartedTestSuite):
     @testcase("Check that --version output contains information required by third party libraries(client package)")
     def test_license_info_client_package(self):
         self.installer.install_client_package()
-        binaries = [file for file in self.installer.arango_binaries if file.path.name in self.binary_file_names]
+        binaries = [
+            file
+            for file in self.installer.arango_binaries
+            if file.path.name in self.binary_file_names and not (not self.run_props.enterprise and file.enterprise)
+        ]
         for bin in binaries:
             with step(f"check {bin.name}"):
                 bin.check_license_info()


### PR DESCRIPTION
Add tests to check that`  --version`  output contains license information from third party libs. This test is only for versions 3.12+.