### PR TITLE
adding vpack sorting test

### DIFF
--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -62,8 +62,8 @@ def detect_file_ulimit():
 
 def detect_locale():
     """check that system locale is set correctly"""
-    if sys.platform != "linux":
-        return
+    # if sys.platform != "linux":
+    return
 
     locale_env = {
         "LANG": r"en_US(|:.*)",

--- a/release_tester/arangodb/starter/deployments/runner.py
+++ b/release_tester/arangodb/starter/deployments/runner.py
@@ -62,8 +62,8 @@ def detect_file_ulimit():
 
 def detect_locale():
     """check that system locale is set correctly"""
-    # if sys.platform != "linux":
-    return
+    if sys.platform != "linux":
+        return
 
     locale_env = {
         "LANG": r"en_US(|:.*)",


### PR DESCRIPTION
### Scope & Purpose
This PR adds a test for validating VPack numerical sorting in ArangoDB, specifically addressing sorting behavior for large numeric values across different versions.

### Problem
Large numeric values were previously cast to doubles for comparison, leading to incorrect sorting and potential data corruption in RocksDB. The issue is fixed in versions 3.12.2 and 3.11.11, introducing a new comparator that requires migration for proper sorting.

### Test Script
Insert Test Data: Add documents with large numeric values to test collections.
Initial Sorting Check:
Versions < 3.11.11 and < 3.12.2: Verify incorrect sorting (z, x, y).
Versions >= 3.11.11 and >= 3.12.2: Verify correct sorting (y, z, x).
Upgrade & Migration: Upgrade ArangoDB, run the migration, and verify sorting changes.
Final Check: Ensure correct sorting and data integrity after migration.


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] sidelining PRs
  - [x] https://github.com/arangodb/rta-makedata/pull/41
  - [x] https://github.com/arangodb/release-test-automation/pull/508