### PR TITLE
Support for running Selenium tests on ARM64 Linux

### DIFF
--- a/release_tester/arangodb/starter/deployments/selenium_deployments/selenium_session_spawner.py
+++ b/release_tester/arangodb/starter/deployments/selenium_deployments/selenium_session_spawner.py
@@ -2,18 +2,19 @@
 """ baseclass to manage selenium UI tests """
 
 import time
+import shutil
 from datetime import datetime
 
 from selenium import webdriver
-from selenium.common.exceptions import SessionNotCreatedException
+from selenium.common.exceptions import SessionNotCreatedException, NoSuchDriverException
 
 from arangodb.starter.deployments.selenium_deployments.selenoid_swiper import cleanup_temp_files
 
 # pylint: disable=import-outside-toplevel disable=too-many-locals
 # pylint: disable=too-many-branches disable=too-many-statements
 # pylint: disable=too-many-return-statements
-def spawn_selenium_session(selenium_worker: str,  selenium_driver_args: list):
-    """ launch selenium if prompted and return the instance """
+def spawn_selenium_session(selenium_worker: str, selenium_driver_args: list):
+    """launch selenium if prompted and return the instance"""
     if "_" in selenium_worker:
         sw_split = selenium_worker.split("_")
         driver_func = getattr(webdriver, sw_split[0])
@@ -29,9 +30,7 @@ def spawn_selenium_session(selenium_worker: str,  selenium_driver_args: list):
     kwargs = {}
     is_headless = False
     if len(selenium_driver_args) > 0:
-        opts_func = getattr(webdriver, selenium_worker)
-        opts_func = getattr(opts_func, "options")
-        opts_func = getattr(opts_func, "Options")
+        opts_func = get_options_service_func(webdriver, selenium_worker)
         options = opts_func()
         kwargs[worker_options + "options"] = options
         selenoid_options = {}
@@ -76,6 +75,14 @@ def spawn_selenium_session(selenium_worker: str,  selenium_driver_args: list):
         try:
             driver = driver_func(**kwargs)
             video_start_time = datetime.now()
+        except NoSuchDriverException as ex:
+            browser_driver = {"chrome": f"{selenium_worker}driver", "firefox": "geckodriver"}[selenium_worker]
+            print(f"'{type(ex).__name__}' caught - we are on arm64/linux, path to '{browser_driver}' has to be set...")
+            browser_driver_path = shutil.which(browser_driver)
+            service_func = get_options_service_func(webdriver, selenium_worker, func_type="service")
+            kwargs["service"] = service_func(executable_path=browser_driver_path)
+            driver = driver_func(**kwargs)
+            video_start_time = datetime.now()
         except TypeError:
             try:
                 driver = driver_func.webdriver.WebDriver(**kwargs)
@@ -96,4 +103,11 @@ def spawn_selenium_session(selenium_worker: str,  selenium_driver_args: list):
         required_width = driver.execute_script("return document.body.parentNode.scrollWidth")
         required_height = driver.execute_script("return document.body.parentNode.scrollHeight")
         driver.set_window_size(required_width, required_height)
-    return (is_headless, driver,  video_start_time)
+    return (is_headless, driver, video_start_time)
+
+
+def get_options_service_func(driver, worker, func_type="options"):
+    """returns Options or Service object/function for specified browser"""
+    func = getattr(driver, worker)
+    func = getattr(func, func_type.lower())
+    return getattr(func, func_type.capitalize())


### PR DESCRIPTION
This PR adds support for RTA Selenium UI tests execution on ARM64 Linux. 

Driver is instantiated in `selenium_session_spawner.py` via a `driver_func` call to which in addition to existing `Options` a `Service` object needs to be passed. This `Service` object contains a named `executable_path` parameter which points to the browser driver. Both `chromedriver` (Chromium) and `geckodriver` (Firefox) are supported. 

_chromedriver and geckodriver have to be available in the system as they are discovered with shutil.which()_
