### PR TITLE
AnalyzerTestSuite splitting into 2 smaller independent parts

### DIFF
--- a/release_tester/selenium_ui_test/pages/analyzers_page.py
+++ b/release_tester/selenium_ui_test/pages/analyzers_page.py
@@ -2,8 +2,6 @@
 """ analyzer page object """
 import time
 import traceback
-import json
-import pathlib
 from collections import namedtuple
 import semver
 from selenium_ui_test.pages.base_page import Keys
@@ -25,15 +23,9 @@ class AnalyzerPage(NavigationBarPage):
                                   "and not(ancestor::div[contains(@style,'display: none')])] "
         self.index = 0
         self.package_version = self.current_package_version()
-        # external page elements
+        # enabling external page locators for analyzer page
         ui_version = 'new_ui' if self.version_is_newer_than('3.11.99') else 'old_ui'
-        elements_json_path = f'{pathlib.Path(__file__).parent.resolve()}/elements.json'
-        print(f'UI elements JSON file path - {elements_json_path}')
-        elements_data = {}
-        with open(elements_json_path, 'r', encoding='utf-8') as file:
-            elements_data = json.load(file)
-        elements_dict = dict(elements_data[self.analyzers_page][ui_version])
-        # pylint: disable=invalid-name
+        elements_dict = dict(self.elements_data[self.analyzers_page][ui_version])
         Elements = namedtuple("Elements", list(elements_dict.keys())) # pylint: disable=C0103
         self.elements = Elements(*list(elements_dict.values()))
 
@@ -238,15 +230,15 @@ class AnalyzerPage(NavigationBarPage):
             "My_Stopwords_Analyzer": 7,
             "My_Collation_Analyzer": 8,
             "My_Segmentation_Alpha_Analyzer": 9,
-            "My_Nearest_Neighbor_Analyzer": 10 if self.version_is_newer_than('3.9.99') else 9,
-            "My_Classification_Analyzer": 11 if self.version_is_newer_than('3.9.99') else 9,
-            "My_Pipeline_Analyzer": 12 if self.version_is_newer_than('3.9.99') else 10,
-            "My_GeoJSON_Analyzer": 13 if self.version_is_newer_than('3.9.99') else 11,
-            "My_GeoPoint_Analyzer": 14 if self.version_is_newer_than('3.9.99') else 12,
-            "My_GeoS2_Analyzer": 15 if self.version_is_newer_than('3.9.99') else 13,
-            "My_Minhash_Analyzer": 16 if self.version_is_newer_than('3.9.99') else 14,
-            "My_MultiDelimiter_Analyzer": 17 if self.version_is_newer_than('3.9.99') else 15,
-            "My_WildCard_Analyzer": 18 if self.version_is_newer_than('3.9.99') else 16
+            "My_Nearest_Neighbor_Analyzer": 10,
+            "My_Classification_Analyzer": 11,
+            "My_Pipeline_Analyzer": 12,
+            "My_GeoJSON_Analyzer": 13,
+            "My_GeoPoint_Analyzer": 14,
+            "My_GeoS2_Analyzer": 15,
+            "My_Minhash_Analyzer": 16,
+            "My_MultiDelimiter_Analyzer": 17,
+            "My_WildCard_Analyzer": 18
         }
         return analyzer_lookup.get(name, -1)  # Return -1 if the analyzer name is not found
 

--- a/release_tester/selenium_ui_test/pages/analyzers_page.py
+++ b/release_tester/selenium_ui_test/pages/analyzers_page.py
@@ -2,10 +2,10 @@
 """ analyzer page object """
 import time
 import traceback
-import semver
 import json
 import pathlib
 from collections import namedtuple
+import semver
 from selenium_ui_test.pages.base_page import Keys
 from selenium_ui_test.pages.navbar import NavigationBarPage
 from selenium.webdriver.common.by import By
@@ -30,10 +30,11 @@ class AnalyzerPage(NavigationBarPage):
         elements_json_path = f'{pathlib.Path(__file__).parent.resolve()}/elements.json'
         print(f'UI elements JSON file path - {elements_json_path}')
         elements_data = {}
-        with open(elements_json_path, 'r') as file:
+        with open(elements_json_path, 'r', encoding='utf-8') as file:
             elements_data = json.load(file)
         elements_dict = dict(elements_data[self.analyzers_page][ui_version])
-        Elements = namedtuple("Elements", list(elements_dict.keys()))
+        # pylint: disable=invalid-name
+        Elements = namedtuple("Elements", list(elements_dict.keys())) # pylint: disable=C0103
         self.elements = Elements(*list(elements_dict.values()))
 
     def select_analyzers_page(self):
@@ -1925,29 +1926,36 @@ class AnalyzerPage(NavigationBarPage):
         return analyzers[analyzer_name]
 
 
-    def creating_all_supported_analyzer(self, enterprise, model_location=None):
+    def creating_all_supported_analyzer(self, enterprise, model_location=None, analyzer_set=1):
         """This method will create all the supported version-specific analyzers"""
-        decode_analyzers = {
-            "My_Identity_Analyzer": (0, None, False),
-            "My_Delimiter_Analyzer": (0, None, False),
-            "My_Stem_Analyzer": (0, None, False),
-            "My_Norm_Analyzer": (0, None, False),
-            "My_N-Gram_Analyzer": (0, None, False),
-            "My_Text_Analyzer": (0, None, False),
-            "My_AQL_Analyzer": (0, None, False),
-            "My_Stopwords_Analyzer": (0, None, False),
-            "My_Collation_Analyzer": (0, None, False),
-            "My_Segmentation_Alpha_Analyzer": (0, None, False),
-            "My_Pipeline_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
-            "My_GeoJSON_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
-            "My_GeoPoint_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
-            "My_MultiDelimiter_Analyzer": (0, semver.VersionInfo.parse('3.11.99'), False),
-            "My_WildCard_Analyzer": (0, semver.VersionInfo.parse('3.11.99'), False),
-            "My_Minhash_Analyzer": (0, semver.VersionInfo.parse('3.11.99'), not (enterprise and self.version_is_newer_than('3.11.99'))),
-            "My_Nearest_Neighbor_Analyzer": (1 if enterprise else 0, semver.VersionInfo.parse('3.10.0'), not enterprise),
-            "My_Classification_Analyzer": (1 if enterprise else 0, semver.VersionInfo.parse('3.10.0'), not enterprise),
-            "My_GeoS2_Analyzer": (0, None, not enterprise)
-        }
+        if analyzer_set == 1:
+            decode_analyzers = {
+                "My_Identity_Analyzer": (0, None, False),
+                "My_Delimiter_Analyzer": (0, None, False),
+                "My_Stem_Analyzer": (0, None, False),
+                "My_Norm_Analyzer": (0, None, False),
+                "My_N-Gram_Analyzer": (0, None, False),
+                "My_Text_Analyzer": (0, None, False),
+                "My_AQL_Analyzer": (0, None, False),
+                "My_Stopwords_Analyzer": (0, None, False),
+                "My_Collation_Analyzer": (0, None, False),
+                "My_Segmentation_Alpha_Analyzer": (0, None, False)
+            }
+        else:
+            decode_analyzers = {
+                "My_Pipeline_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
+                "My_GeoJSON_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
+                "My_GeoPoint_Analyzer": (0, semver.VersionInfo.parse('3.10.0'), False),
+                "My_MultiDelimiter_Analyzer": (0, semver.VersionInfo.parse('3.11.99'), False),
+                "My_WildCard_Analyzer": (0, semver.VersionInfo.parse('3.11.99'), False),
+                "My_Minhash_Analyzer": (0, semver.VersionInfo.parse('3.11.99'),
+                                        not (enterprise and self.version_is_newer_than('3.11.99'))),
+                "My_Nearest_Neighbor_Analyzer": (1 if enterprise else 0, semver.VersionInfo.parse('3.10.0'),
+                                                 not enterprise),
+                "My_Classification_Analyzer": (1 if enterprise else 0, semver.VersionInfo.parse('3.10.0'),
+                                               not enterprise),
+                "My_GeoS2_Analyzer": (0, None, not enterprise)
+            }
 
         # Loop through each analyzer in the dictionary
         for analyzer_name, config in decode_analyzers.items():
@@ -2294,26 +2302,28 @@ class AnalyzerPage(NavigationBarPage):
             traceback.print_exc()
             raise Exception('Critical Error occurred and need manual inspection!! \n') from ex
 
-    def deleting_all_created_analyzers(self):
+    def deleting_all_created_analyzers(self, analyzer_set=1):
         """Deleting all the created analyzers"""
-        self.delete_analyzer('My_AQL_Analyzer')
-        self.delete_analyzer('My_Collation_Analyzer')
-        self.delete_analyzer('My_Delimiter_Analyzer')
-        self.delete_analyzer('My_GeoJSON_Analyzer')
-        self.delete_analyzer('My_GeoPoint_Analyzer')
-        self.delete_analyzer('My_Identity_Analyzer')
-        self.delete_analyzer('My_N-Gram_Analyzer')
-        self.delete_analyzer('My_Norm_Analyzer')
-        self.delete_analyzer('My_Pipeline_Analyzer')
-        self.delete_analyzer('My_Segmentation_Alpha_Analyzer')
-        self.delete_analyzer('My_Stem_Analyzer')
-        self.delete_analyzer('My_Stopwords_Analyzer')
-        self.delete_analyzer('My_Text_Analyzer')
-        self.delete_analyzer('My_Nearest_Neighbor_Analyzer')
-        self.delete_analyzer('My_Classification_Analyzer')
-        self.delete_analyzer('My_GeoS2_Analyzer')
-        if self.version_is_newer_than('3.11.99'):
-            self.delete_analyzer('My_Minhash_Analyzer')
-            self.delete_analyzer('My_MultiDelimiter_Analyzer')
-            self.delete_analyzer('My_WildCard_Analyzer')
+        if analyzer_set == 1:
+            self.delete_analyzer('My_Identity_Analyzer')
+            self.delete_analyzer('My_Delimiter_Analyzer')
+            self.delete_analyzer('My_Stem_Analyzer')
+            self.delete_analyzer('My_Norm_Analyzer')
+            self.delete_analyzer('My_N-Gram_Analyzer')
+            self.delete_analyzer('My_Text_Analyzer')
+            self.delete_analyzer('My_AQL_Analyzer')
+            self.delete_analyzer('My_Stopwords_Analyzer')
+            self.delete_analyzer('My_Collation_Analyzer')
+            self.delete_analyzer('My_Segmentation_Alpha_Analyzer')
+        else:
+            self.delete_analyzer('My_Pipeline_Analyzer')
+            self.delete_analyzer('My_GeoJSON_Analyzer')
+            self.delete_analyzer('My_GeoPoint_Analyzer')
+            self.delete_analyzer('My_Nearest_Neighbor_Analyzer')
+            self.delete_analyzer('My_Classification_Analyzer')
+            self.delete_analyzer('My_GeoS2_Analyzer')
+            if self.version_is_newer_than('3.11.99'):
+                self.delete_analyzer('My_Minhash_Analyzer')
+                self.delete_analyzer('My_MultiDelimiter_Analyzer')
+                self.delete_analyzer('My_WildCard_Analyzer')
         self.tprint('All the created analyzers have been deleted \n')

--- a/release_tester/selenium_ui_test/pages/base_page.py
+++ b/release_tester/selenium_ui_test/pages/base_page.py
@@ -2,6 +2,8 @@
 """ base page object """
 import time
 import traceback
+import json
+import pathlib
 from datetime import datetime
 
 import tools.interact as ti
@@ -52,6 +54,11 @@ class BasePage:
         self.locator = None
         self.select = None
         self.current = None
+        # external element locators
+        elements_json_path = f'{pathlib.Path(__file__).parent.resolve()}/elements.json'
+        self.elements_data = {}
+        with open(elements_json_path, 'r', encoding='utf-8') as file:
+            self.elements_data = json.load(file)
 
     def tprint(self, string):
         """print including timestamp relative to video start"""

--- a/release_tester/selenium_ui_test/test_suites/analyzers_test_suite_1.py
+++ b/release_tester/selenium_ui_test/test_suites/analyzers_test_suite_1.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+""" analyzer page testsuite """
+import traceback
+import semver
+
+from selenium_ui_test.pages.analyzers_page import AnalyzerPage
+from selenium_ui_test.test_suites.base_selenium_test_suite import BaseSeleniumTestSuite
+from test_suites_core.base_test_suite import testcase
+
+
+class AnalyzersTestSuite1(BaseSeleniumTestSuite):
+    """ analyzer page testsuite """
+    @testcase
+    def test_analyzers(self):
+        """ analyzer page test set 1 """
+        # pylint: disable=too-many-statements
+        self.tprint("---------Analyzers Page Test Set 1 Begin--------- \n")
+        analyzers = AnalyzerPage(self.webdriver, self.cfg, self.video_start_time)
+
+        assert analyzers.current_user() == "ROOT", "current user is root?"
+        assert analyzers.current_database() == "_SYSTEM", "current database is _system?"
+
+        self.exception = False
+        self.error = None
+        package_version = analyzers.current_package_version()
+        try:
+            if package_version >= semver.VersionInfo.parse("3.9.0"):
+                analyzers.select_analyzers_page()
+                analyzers.select_help_filter_btn()
+
+                self.tprint('Checking analyzer page transition\n')
+                analyzers.checking_analyzer_page_transition('transition')
+
+                if package_version < semver.VersionInfo.parse("3.11.0"):
+                    self.tprint('Checking all built-in analyzers\n')
+                    analyzers.checking_all_built_in_analyzer()
+
+                self.tprint('Creating all supported analyzers\n')
+                analyzers.creating_all_supported_analyzer(self.is_enterprise, self.ui_data_dir, analyzer_set=1)
+
+                self.tprint('Checking expected negative scenarios for analyzers\n')
+                analyzers.analyzer_expected_error_check()
+
+                self.tprint("Checking analyzer's search filter options \n")
+                analyzers.checking_search_filter()
+            else:
+                self.tprint("Analyzer test is not available version below 3.9.0 \n")
+
+        except BaseException:
+            self.tprint(f"{'x' * 45}\nINFO: Error Occurred! Force Deletion Started\n{'x' * 45}")
+            self.exception = True  # mark the exception status as true
+            self.error = traceback.format_exc()
+
+        finally:
+            analyzers.print_combined_performance_results()
+            if package_version >= semver.VersionInfo.parse("3.9.0"):
+                self.tprint("Analyzer deletion started.")
+                analyzers.deleting_all_created_analyzers(analyzer_set=1)
+                del analyzers
+                self.tprint("---------Analyzers Page Test Set 1 Completed--------- \n")
+                if self.exception:
+                    raise Exception(self.error)

--- a/release_tester/selenium_ui_test/test_suites/analyzers_test_suite_2.py
+++ b/release_tester/selenium_ui_test/test_suites/analyzers_test_suite_2.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+""" analyzer page testsuite """
+import traceback
+import semver
+
+from selenium_ui_test.pages.analyzers_page import AnalyzerPage
+from selenium_ui_test.test_suites.base_selenium_test_suite import BaseSeleniumTestSuite
+from test_suites_core.base_test_suite import testcase
+
+
+class AnalyzersTestSuite2(BaseSeleniumTestSuite):
+    """ analyzer page testsuite """
+    @testcase
+    def test_analyzers(self):
+        """ analyzer page test set 2 """
+        # pylint: disable=too-many-statements
+        self.tprint("---------Analyzers Page Test Set 2 Begin--------- \n")
+        analyzers = AnalyzerPage(self.webdriver, self.cfg, self.video_start_time)
+
+        assert analyzers.current_user() == "ROOT", "current user is root?"
+        assert analyzers.current_database() == "_SYSTEM", "current database is _system?"
+
+        self.exception = False
+        self.error = None
+        package_version = analyzers.current_package_version()
+        try:
+            if package_version >= semver.VersionInfo.parse("3.9.0"):
+                analyzers.select_analyzers_page()
+                analyzers.select_help_filter_btn()
+
+                self.tprint('Checking analyzer page transition\n')
+                analyzers.checking_analyzer_page_transition('transition')
+
+                if package_version < semver.VersionInfo.parse("3.11.0"):
+                    self.tprint('Checking all built-in analyzers\n')
+                    analyzers.checking_all_built_in_analyzer()
+
+                self.tprint('Creating all supported analyzers\n')
+                analyzers.creating_all_supported_analyzer(self.is_enterprise, self.ui_data_dir, analyzer_set=2)
+
+                self.tprint('Checking expected negative scenarios for analyzers\n')
+                analyzers.analyzer_expected_error_check()
+
+                self.tprint("Checking analyzer's search filter options \n")
+                analyzers.checking_search_filter()
+            else:
+                self.tprint("Analyzer test is not available version below 3.9.0 \n")
+
+        except BaseException:
+            self.tprint(f"{'x' * 45}\nINFO: Error Occurred! Force Deletion Started\n{'x' * 45}")
+            self.exception = True  # mark the exception status as true
+            self.error = traceback.format_exc()
+
+        finally:
+            analyzers.print_combined_performance_results()
+            if package_version >= semver.VersionInfo.parse("3.9.0"):
+                self.tprint("Analyzer deletion started.")
+                analyzers.deleting_all_created_analyzers(analyzer_set=2)
+                del analyzers
+                self.tprint("---------Analyzers Page Test Set 2 Completed--------- \n")
+                if self.exception:
+                    raise Exception(self.error)

--- a/release_tester/selenium_ui_test/test_suites/basic_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/basic_test_suite.py
@@ -10,7 +10,8 @@ from selenium_ui_test.test_suites.collections_test_suite import CollectionsTestS
 from selenium_ui_test.test_suites.graph_test_suite import GraphTestSuite
 from selenium_ui_test.test_suites.query_test_suite import QueryTestSuite
 from selenium_ui_test.test_suites.views_test_suite import ViewsTestSuite
-from selenium_ui_test.test_suites.analyzers_test_suite import AnalyzersTestSuite
+from selenium_ui_test.test_suites.analyzers_test_suite_1 import AnalyzersTestSuite1
+from selenium_ui_test.test_suites.analyzers_test_suite_2 import AnalyzersTestSuite2
 from selenium_ui_test.test_suites.service_test_suit import ServiceTestSuite
 
 
@@ -23,7 +24,8 @@ class BasicTestSuite(BaseSeleniumTestSuite):
         ViewsTestSuite,
         GraphTestSuite,
         QueryTestSuite,
-        AnalyzersTestSuite,
+        AnalyzersTestSuite1,
+        AnalyzersTestSuite2,
         DatabaseTestSuite,
         LogInTestSuite,
         DashboardTestSuite,


### PR DESCRIPTION
* AnalyzerTestSuite splitting into 2 smaller independent suites to decrease run duration when running Analyzer tests in parallel (parallel CircleCI jobs)
* Addressed pylint errors/warnings 
* Moved loading of `elements.json` to `base_page.py` to facilitate future 'migration' to externally stored element locators in other page classes.