### PR TITLE
QA-638: make Analyzer tests run again against 3.11, fix for WebDriver error in 'check for the follower count' test

### DIFF
--- a/release_tester/selenium_ui_test/pages/analyzers_page.py
+++ b/release_tester/selenium_ui_test/pages/analyzers_page.py
@@ -990,7 +990,7 @@ class AnalyzerPage(NavigationBarPage):
         self.tprint(f"Creating {name} completed successfully \n")
 
         # --------------------here we are checking the properties of the created analyzer----------------------
-        if self.version_is_older_than('3.11.99'):
+        if self.version_is_older_than('3.11.0'):
             # primariliy enable the test for the version below 3.11.99
             if name in ["My_Nearest_Neighbor_Analyzer", "My_Classification_Analyzer"]:
                 self.tprint(f"Skipping the properties check for {name} \n") #todo: need to fix this for 3.11.x, location porperties has changed due to the dynamic selenoid depoloyment

--- a/release_tester/selenium_ui_test/pages/analyzers_page.py
+++ b/release_tester/selenium_ui_test/pages/analyzers_page.py
@@ -148,7 +148,7 @@ class AnalyzerPage(NavigationBarPage):
         # Click the search icon from the search/filter box if it takes
         # to the collection page then it's an error.
 
-        if self.version_is_newer_than('3.11.99'):
+        if self.version_is_newer_than('3.11.0'):
             self.tprint("checking_analyzer_page_transition test skipped \n")
         else:
             self.navbar_goto("analyzers")
@@ -2211,7 +2211,7 @@ class AnalyzerPage(NavigationBarPage):
 
     def analyzer_expected_error_check(self):
         """This will call all the error scenario methods"""
-        if self.version_is_newer_than('3.11.99'):
+        if self.version_is_newer_than('3.11.0'):
             self.tprint('Skipped \n')
         else:
             self.tprint('Checking negative scenario for the identity analyzers name \n')
@@ -2226,7 +2226,7 @@ class AnalyzerPage(NavigationBarPage):
 
     def checking_search_filter(self):
         """This method will check analyzer's search filter option"""
-        if self.version_is_newer_than('3.11.99'):
+        if self.version_is_newer_than('3.11.0'):
             self.tprint("Skipped \n")
         else:
             self.tprint('Checking analyzer search filter options started \n')

--- a/release_tester/selenium_ui_test/pages/elements.json
+++ b/release_tester/selenium_ui_test/pages/elements.json
@@ -108,7 +108,7 @@
       ["txt_longitude", "//div[label[text()='Longitude Path']]//input[not(@disabled)]"],
       ["txt_geo_point_max_s2_cells", "//div[label[text()='Max S2 Cells']]//input[not(@disabled)]"],
       ["select_geo_s2_analyzer_type", "(//label[normalize-space()='Type'])[1]"],
-      ["select_geo_s2_analyzer_format", "(//label[normalize-space()='format'])[1]"],
+      ["select_geo_s2_analyzer_format", "(//label[normalize-space()='Format'])[1]"],
       ["txt_geo_s2_max_s2_cells", "//*[text()='Max S2 Cells']"],
       ["txt_geo_s2_least_precise_s2_level", "//*[text()='Least Precise S2 Level']"],
       ["txt_geo_s2_most_precise_s2_level", "//*[text()='Most Precise S2 Level']"],

--- a/release_tester/selenium_ui_test/pages/replication_page.py
+++ b/release_tester/selenium_ui_test/pages/replication_page.py
@@ -68,7 +68,7 @@ class ReplicationPage(NavigationBarPage):
         )
         state_table = {}
         for key in self.REPL_TABLE_LOC.items():
-            state_table[key[0]] = table_elm.find_element_by_xpath(key[1]).text
+            state_table[key[0]] = table_elm.find_element(By.XPATH, key[1]).text
         return state_table
 
     def get_replication_screen(self, is_leader, timeout=20):


### PR DESCRIPTION
This PR inroduces the following changes:
* disables some of the extended `Analyzer` tests that are failing when run against ADB `3.11.x` 
* fixes WebDriver error related to the deprecated method in 'check for the follower count' test (`replication_page.py`)
