### PR TITLE
QA-642: Fixes for AFO ActiveFailoverJamStepOneSuite tests

### DIFF
--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -354,13 +354,14 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
+            curr_leader_port = curr_leader.get_frontend().get_local_url("").split(":")[2]
             print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
-            print(f'current leader port - << {curr_leader.port} >>')
-            resilient_instance = [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0]
+            print(f'current leader port - << {curr_leader_port} >>')
             print(f'leader.all_instances - {self.leader.all_instances}')
+            resilient_instance = [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0]
             print(f'resilient instance - {resilient_instance}, its port - {resilient_instance.port}')
             # self.set_selenium_instances()
-            resilient_instance.port = curr_leader.port
+            resilient_instance.port = int(curr_leader_port)
             self.set_new_selenium_instances(resilient_instance)
             self.selenium.test_jam_attempt()
 

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -354,9 +354,14 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
+            print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
+            print(f'current leader port - << {curr_leader.port} >>')
+            resilient_instance = [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0]
+            print(f'leader.all_instances - {self.leader.all_instances}')
+            print(f'resilient instance - {resilient_instance}, its port - {resilient_instance.port}')
             # self.set_selenium_instances()
-            self.set_new_selenium_instances(curr_leader)
-            print(f'current leader url - << {curr_leader.get_frontend().get_public_url("")} >>')
+            resilient_instance.port = curr_leader.port
+            self.set_new_selenium_instances(resilient_instance)
             self.selenium.test_jam_attempt()
 
         prompt_user(
@@ -423,8 +428,6 @@ please revalidate the UI states on the new leader; you should see *one* follower
 
     def set_selenium_instances(self):
         """set instances in selenium runner"""
-        print(f'leader.all_instances - {self.leader.all_instances}')
-        print(f'resilient instance - {[x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE]}')
         self.selenium.set_instances(
             self.cfg,
             self.leader.arango_importer,
@@ -435,9 +438,6 @@ please revalidate the UI states on the new leader; you should see *one* follower
 
     def set_new_selenium_instances(self, new_leader):
         """set instances in selenium runner"""
-        print(f'new leader - {new_leader.all_instances}')
-        print(f'leader.all_instances - {self.leader.all_instances}')
-        print(f'resilient instance - {[x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE]}')
         self.selenium.set_instances(
             self.cfg,
             self.leader.arango_importer,

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -354,8 +354,9 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
-            self.set_selenium_instances()
-            print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
+            # self.set_selenium_instances()
+            self.set_new_selenium_instances(curr_leader)
+            print(f'current leader url - << {curr_leader.get_frontend().get_public_url("")} >>')
             self.selenium.test_jam_attempt()
 
         prompt_user(
@@ -422,12 +423,25 @@ please revalidate the UI states on the new leader; you should see *one* follower
 
     def set_selenium_instances(self):
         """set instances in selenium runner"""
-        print(self.leader.all_instances)
-        print([x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE])
+        print(f'leader.all_instances - {self.leader.all_instances}')
+        print(f'resilient instance - {[x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE]}')
         self.selenium.set_instances(
             self.cfg,
             self.leader.arango_importer,
             self.leader.arango_restore,
             [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0],
+            self.new_cfg,
+        )
+
+    def set_new_selenium_instances(self, new_leader):
+        """set instances in selenium runner"""
+        print(f'new leader - {new_leader.all_instances}')
+        print(f'leader.all_instances - {self.leader.all_instances}')
+        print(f'resilient instance - {[x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE]}')
+        self.selenium.set_instances(
+            self.cfg,
+            self.leader.arango_importer,
+            self.leader.arango_restore,
+            new_leader,
             self.new_cfg,
         )

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -354,7 +354,9 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
-            self.set_selenium_instances()
+            # self.set_selenium_instances()
+            print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
+            self.set_new_selenium_instances(curr_leader.get_frontend().get_local_url(""))
             self.selenium.test_jam_attempt()
 
         prompt_user(
@@ -426,5 +428,15 @@ please revalidate the UI states on the new leader; you should see *one* follower
             self.leader.arango_importer,
             self.leader.arango_restore,
             [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0],
+            self.new_cfg,
+        )
+
+    def set_new_selenium_instances(self, leader_url):
+        """set instances in selenium runner"""
+        self.selenium.set_instances(
+            self.cfg,
+            self.leader.arango_importer,
+            self.leader.arango_restore,
+            leader_url,
             self.new_cfg,
         )

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -354,9 +354,8 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
-            # self.set_selenium_instances()
+            self.set_selenium_instances()
             print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
-            self.set_new_selenium_instances(curr_leader.get_frontend().get_local_url(""))
             self.selenium.test_jam_attempt()
 
         prompt_user(
@@ -423,20 +422,12 @@ please revalidate the UI states on the new leader; you should see *one* follower
 
     def set_selenium_instances(self):
         """set instances in selenium runner"""
+        print(self.leader.all_instances)
+        print([x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE])
         self.selenium.set_instances(
             self.cfg,
             self.leader.arango_importer,
             self.leader.arango_restore,
             [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0],
-            self.new_cfg,
-        )
-
-    def set_new_selenium_instances(self, leader_url):
-        """set instances in selenium runner"""
-        self.selenium.set_instances(
-            self.cfg,
-            self.leader.arango_importer,
-            self.leader.arango_restore,
-            leader_url,
             self.new_cfg,
         )

--- a/release_tester/arangodb/starter/deployments/activefailover.py
+++ b/release_tester/arangodb/starter/deployments/activefailover.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 import time
+import re
 from pathlib import Path
 
 import requests
@@ -354,14 +355,16 @@ class ActiveFailover(Runner):
 
         if self.selenium:
             # cfg = self.new_cfg if self.new_cfg else self.cfg
-            curr_leader_port = curr_leader.get_frontend().get_local_url("").split(":")[2]
-            print(f'current leader url - << {curr_leader.get_frontend().get_local_url("")} >>')
+            curr_leader_local_url = curr_leader.get_frontend().get_local_url("")
+            curr_leader_port = int(re.search('(?<=:)\d{4}', curr_leader_local_url).group())
+            # curr_leader_port = curr_leader.get_frontend().get_local_url("").split(":")[2]
+            print(f'current leader url - << {curr_leader_local_url} >>')
             print(f'current leader port - << {curr_leader_port} >>')
             print(f'leader.all_instances - {self.leader.all_instances}')
             resilient_instance = [x for x in self.leader.all_instances if x.instance_type == InstanceType.RESILIENT_SINGLE][0]
-            print(f'resilient instance - {resilient_instance}, its port - {resilient_instance.port}')
+            # print(f'resilient instance - {resilient_instance}, its port - {resilient_instance.port}')
             # self.set_selenium_instances()
-            resilient_instance.port = int(curr_leader_port)
+            resilient_instance.port = curr_leader_port
             self.set_new_selenium_instances(resilient_instance)
             self.selenium.test_jam_attempt()
 

--- a/release_tester/selenium_ui_test/pages/replication_page.py
+++ b/release_tester/selenium_ui_test/pages/replication_page.py
@@ -111,16 +111,19 @@ class ReplicationPage(NavigationBarPage):
         time.sleep(1)
         assert replication_mode == "Active Failover", f"Expected Active Failover but got {replication_mode}"
 
-        ip_list = ["tcp://localhost:9529", "tcp://localhost:9629", "tcp://localhost:9729"]
+        url_list = ["tcp://localhost:9529", "tcp://localhost:9629", "tcp://localhost:9729",
+                    "ssl://localhost:9529", "ssl://localhost:9629", "ssl://localhost:9729"]
 
-        self.tprint("checking leader id\n")
+        self.tprint("checking leader ip\n")
         leader_id_sitem = self.locator_finder_by_xpath_or_css_selector(self.elements.txt_nodes_leader)
         leader = leader_id_sitem.text
+        print(f"leader url - {leader}")
         time.sleep(1)
-        assert leader in ip_list, "Error occurred, Couldn't find expected leader ip"
+        assert leader in url_list, "Error occurred, Couldn't find expected leader url"
 
-        self.tprint("checking follower id\n")
+        self.tprint("checking follower ip\n")
         follower_id_sitem = self.locator_finder_by_xpath_or_css_selector(self.elements.txt_nodes_follower)
         follower = follower_id_sitem.text
+        print(f"follower url - {leader}")
         time.sleep(1)
-        assert follower in ip_list, "Error occurred, Couldn't find expected follower ip"
+        assert follower in url_list, "Error occurred, Couldn't find expected follower url"

--- a/release_tester/selenium_ui_test/pages/replication_page.py
+++ b/release_tester/selenium_ui_test/pages/replication_page.py
@@ -114,16 +114,14 @@ class ReplicationPage(NavigationBarPage):
         url_list = ["tcp://localhost:9529", "tcp://localhost:9629", "tcp://localhost:9729",
                     "ssl://localhost:9529", "ssl://localhost:9629", "ssl://localhost:9729"]
 
-        self.tprint("checking leader ip\n")
+        self.tprint("checking leader url\n")
         leader_id_sitem = self.locator_finder_by_xpath_or_css_selector(self.elements.txt_nodes_leader)
         leader = leader_id_sitem.text
-        print(f"leader url - {leader}")
         time.sleep(1)
         assert leader in url_list, "Error occurred, Couldn't find expected leader url"
 
-        self.tprint("checking follower ip\n")
+        self.tprint("checking follower url\n")
         follower_id_sitem = self.locator_finder_by_xpath_or_css_selector(self.elements.txt_nodes_follower)
         follower = follower_id_sitem.text
-        print(f"follower url - {leader}")
         time.sleep(1)
         assert follower in url_list, "Error occurred, Couldn't find expected follower url"

--- a/release_tester/selenium_ui_test/pages/support_page.py
+++ b/release_tester/selenium_ui_test/pages/support_page.py
@@ -135,12 +135,12 @@ class SupportPage(NavigationBarPage):
                 'Recommended Resources | ArangoDB Documentation']
         else:
             manual_link_assertion_check = [
-                'Getting Started | Manual | ArangoDB Documentation',
-                'Modeling Data for ArangoDB | ArangoDB Documentation',
-                'Administration | Manual | ArangoDB Documentation',
-                'Scaling | Manual | ArangoDB Documentation',
-                'Graphs | Manual | ArangoDB Documentation',
-                'Introduction to ArangoDB Documentation | ArangoDB Documentation']
+                'Get Started | ArangoDB Documentation',
+                'Concepts | ArangoDB Documentation',
+                'Administration | ArangoDB Documentation',
+                'ArangoDB Architecture | ArangoDB Documentation',
+                'Graphs | ArangoDB Documentation',
+                'What is ArangoDB? | ArangoDB Documentation']
 
         self.loop_through_link_traversal(
             manual_link_list_print_statement, manual_link_list, manual_link_assertion_check
@@ -175,11 +175,11 @@ class SupportPage(NavigationBarPage):
                                                 'AQL Query Patterns and Examples | ArangoDB Documentation',
                                                 'AQL Documentation | ArangoDB Documentation']
         else:
-            fundamental_link_assertion_check = ['AQL Fundamentals | AQL | ArangoDB Documentation',
+            fundamental_link_assertion_check = ['AQL Fundamentals | ArangoDB Documentation',
                                                 'AQL Data Queries | ArangoDB Documentation',
-                                                'ArangoDB Query Language AQL Functions | ArangoDB Documentation',
-                                                'AQL Query Patterns & Examples | ArangoDB Documentation',
-                                                'ArangoDB Query Language (AQL) Introduction | ArangoDB Documentation']
+                                                'AQL functions | ArangoDB Documentation',
+                                                'AQL Query Patterns and Examples | ArangoDB Documentation',
+                                                'AQL Documentation | ArangoDB Documentation']
 
         self.loop_through_link_traversal(aql_link_list_print_statement, aql_link_list, fundamental_link_assertion_check)
 

--- a/release_tester/selenium_ui_test/test_suites/activefailover/jam_1_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/activefailover/jam_1_test_suite.py
@@ -16,7 +16,8 @@ class ActiveFailoverJamStepOneSuite(ActiveFailoverBaseTestSuite):
         """check for one set of instances to go away"""
         NavigationBarPage(self.webdriver, self.cfg, self.video_start_time).navbar_goto("replication")
         replication_page = ReplicationPage(self.webdriver, self.cfg, self.video_start_time)
-        replication_table = replication_page.get_replication_screen(True, ReplicationPage)
+        # replication_table = replication_page.get_replication_screen(True, ReplicationPage)
+        replication_table = replication_page.get_replication_screen(True, timeout=30)
         self.tprint(replication_table)
         # head and one follower should be there:
         self.ui_assert(

--- a/release_tester/selenium_ui_test/test_suites/base_selenium_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/base_selenium_test_suite.py
@@ -135,6 +135,7 @@ class BaseSeleniumTestSuite(BaseTestSuite):
     def goto_url_and_wait_until_loaded(self, path):
         """goto & wait for loaded"""
         # to account for cases like AFO when FE may not be ready right away
+        print(f'path to load: {self.url + path}')
         load_attempts, delay, counter = 10, 30, 0
         while counter < load_attempts:
             try:

--- a/release_tester/selenium_ui_test/test_suites/base_selenium_test_suite.py
+++ b/release_tester/selenium_ui_test/test_suites/base_selenium_test_suite.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """ base class for all selenium testsuites """
 from datetime import datetime
+from time import sleep
 
 from allure_commons._allure import attach
 from allure_commons.types import AttachmentType
 from beautifultable import BeautifulTable
-from selenium.common.exceptions import InvalidSessionIdException
+from selenium.common.exceptions import InvalidSessionIdException, WebDriverException
 from selenium.webdriver.common.by import By
 from semver import VersionInfo
 
@@ -133,7 +134,18 @@ class BaseSeleniumTestSuite(BaseTestSuite):
 
     def goto_url_and_wait_until_loaded(self, path):
         """goto & wait for loaded"""
-        self.webdriver.get(self.url + path)
+        # to account for cases like AFO when FE may not be ready right away
+        load_attempts, delay, counter = 10, 30, 0
+        while counter < load_attempts:
+            try:
+                self.webdriver.get(self.url + path)
+                break
+            except WebDriverException as ex:
+                print(f"'{type(ex).__name__}' is thrown - FE may not be ready yet...")
+                sleep(delay)
+            counter += 1
+        else:
+            raise Exception(f"FE at '{self.url + path}' still not ready after '{load_attempts * delay}' seconds")
         BasePage(self.webdriver, self.cfg, self.video_start_time).wait_for_ajax()
 
     @run_before_suite


### PR DESCRIPTION
This PR introduces changes aimed at fixing the tests from AFO `ActiveFailoverJamStepOneSuite`.  Tests were failing due to the fact that a FE url of the old leader instance was used instead of the newly promoted follower.

List of changes:
* `deployments/activefailover.py` - a port of the new leader is determined and explicitly set for the resilient_single instance 