### PR TITLE
Disabled isCoveredByStoredValues verification in vi api tests

### DIFF
--- a/release_tester/api_tests/test_suites/vi_stored_values_suite.py
+++ b/release_tester/api_tests/test_suites/vi_stored_values_suite.py
@@ -108,8 +108,8 @@ class VectorIndexStoredValuesTestSuite(APITestSuite):
             # verify no separate filter node
             assert not ph.has_elem_with_prop_value(request2_result["plan"]["nodes"], "type", "FilterNode")
             # verify coverage by stored values
-            index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
-            assert index_node["isCoveredByStoredValues"]
+            # index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
+            # assert index_node["isCoveredByStoredValues"]
             # verify correct optimization rules are applied
             expected_rules = {"move-filters-into-enumerate", "use-vector-index"}
             assert expected_rules.issubset(
@@ -138,8 +138,8 @@ class VectorIndexStoredValuesTestSuite(APITestSuite):
             # verify no separate filter node
             assert not ph.has_elem_with_prop_value(request2_result["plan"]["nodes"], "type", "FilterNode")
             # verify no coverage for non-stored values
-            index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
-            assert not index_node["isCoveredByStoredValues"]
+            # index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
+            # assert not index_node["isCoveredByStoredValues"]
 
     @testcase("3. VI with stored values - complex query (stored values)")
     def test_vi_with_stored_values_complex_query(self):
@@ -169,8 +169,8 @@ class VectorIndexStoredValuesTestSuite(APITestSuite):
             # verify no separate filter node
             assert not ph.has_elem_with_prop_value(request2_result["plan"]["nodes"], "type", "FilterNode")
             # verify coverage by stored values
-            index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
-            assert index_node["isCoveredByStoredValues"]
+            # index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
+            # assert index_node["isCoveredByStoredValues"]
             # verify correct optimization rules are applied
             expected_rules = {"move-filters-into-enumerate", "use-vector-index"}
             assert expected_rules.issubset(
@@ -205,8 +205,8 @@ class VectorIndexStoredValuesTestSuite(APITestSuite):
             # verify no separate filter node
             assert not ph.has_elem_with_prop_value(request2_result["plan"]["nodes"], "type", "FilterNode")
             # verify no coverage for non-stored values
-            index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
-            assert not index_node["isCoveredByStoredValues"]
+            # index_node = ph.find_elem_by_prop_value(request2_result["plan"]["nodes"], "type", "EnumerateNearVectorNode")
+            # assert not index_node["isCoveredByStoredValues"]
 
     @run_after_suite
     def drop_collection(self):


### PR DESCRIPTION
This PR disables isCoveredByStoredValues verification in vi with stored values api tests