### PR TITLE
QA-743: Re-enable positive managed license tests with deployments limit control

### DIFF
--- a/release_tester/license_manager_tests/base/license_manager_base_test_suite.py
+++ b/release_tester/license_manager_tests/base/license_manager_base_test_suite.py
@@ -79,7 +79,7 @@ class LicenseManagerBaseTestSuite(CliStartedTestSuite):
             return True, None
 
     def init_child_class(self, child_class):
-        """initialise the child class"""
+        """initialize the child class"""
         return child_class(self.params)
 
     @run_after_suite
@@ -89,7 +89,7 @@ class LicenseManagerBaseTestSuite(CliStartedTestSuite):
             self.runner.starter_shutdown()
         kill_all_processes()
 
-    @collect_crash_data
+    # @collect_crash_data - disabled as it doesn't always work correctly with other setup/teardown logic
     def save_data_dir(self):
         """save data dir and logs in case a test failed"""
         kill_all_processes()

--- a/release_tester/license_manager_tests/cluster_managed_license.py
+++ b/release_tester/license_manager_tests/cluster_managed_license.py
@@ -25,7 +25,7 @@ class ManagedLicenseClusterTestSuite(LicenseManagerClusterBaseTestSuite, Managed
     @run_before_each_testcase
     @step
     def setup_cluster(self):
-        """recreate a cluster deployment if needed and instantiate LicenseHelper"""
+        """instantiate LicenseHelper and recreate cluster deployment if needed"""
         if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
             self.recreate_deployment()
         self.first_test = False

--- a/release_tester/license_manager_tests/cluster_managed_license.py
+++ b/release_tester/license_manager_tests/cluster_managed_license.py
@@ -6,7 +6,12 @@ from license_manager_tests.base.managed_license_base import ManagedLicenseBaseTe
 from reporting.reporting_utils import step
 from test_suites_core.base_test_suite import testcase, run_before_each_testcase, disable
 from test_suites_core.cli_test_suite import CliTestSuiteParameters
-from license_manager_tests.helpers.license_helper import LicenseHelper, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET
+from license_manager_tests.helpers.license_helper import (
+    LicenseHelper,
+    DEFAULT_CLIENT_ID,
+    DEFAULT_CLIENT_SECRET,
+    MAX_ACTIVE_DEPLOYMENTS,
+)
 
 
 class ManagedLicenseClusterTestSuite(LicenseManagerClusterBaseTestSuite, ManagedLicenseBaseTestSuite):
@@ -15,11 +20,15 @@ class ManagedLicenseClusterTestSuite(LicenseManagerClusterBaseTestSuite, Managed
     def __init__(self, params: CliTestSuiteParameters):
         super().__init__(params)
         self.suite_name = "Managed license test suite: Clean install"
+        self.first_test = True
 
     @run_before_each_testcase
     @step
     def setup_cluster(self):
-        """instantiate LicenseHelper"""
+        """recreate a cluster deployment if needed and instantiate LicenseHelper"""
+        if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
+            self.recreate_deployment()
+        self.first_test = False
         self.lh = LicenseHelper(self.starter, self.lm_tests_dir)
 
     @testcase("1. Attempt to generate a license key with incorrect client id and secret key - Cluster")
@@ -38,30 +47,34 @@ class ManagedLicenseClusterTestSuite(LicenseManagerClusterBaseTestSuite, Managed
     def test_negative_activate_deployment(self):
         """attempt to activate a deployment with incorrect client id and secret key"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment(client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET)
+            command_output = self.lh.activate_deployment(
+                client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET
+            )
         result = self.lh.get_license_data()["json"]
+        assert all([s in command_output for s in ["Error", "401", "unauthorized"]])
         assert not {"license", "grant"}.issubset(result.keys())
         assert "diskUsage" in result
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("3. Generate a license key with operator platform tool and apply the license - Cluster")
     def test_generate_and_apply_license(self):
         """generate a new license key with operator platform tool and apply the license"""
         with step("generate a new license key with operator platform tool"):
             self.lh.generate_license_key()
-        self.lh.apply_license()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+        license_key_file_content = self.lh.get_license_key_file_content()
+        if not MAX_ACTIVE_DEPLOYMENTS in license_key_file_content:  # skip verifications if deployments limit is reached
+            self.lh.apply_license()
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("4. Use operator platform tool to activate deployment - Cluster")
     def test_activate_deployment(self):
         """use operator platform tool to activate deployment"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+            command_output = self.lh.activate_deployment()
+        if not MAX_ACTIVE_DEPLOYMENTS in command_output:  # skip verifications if deployments limit is reached
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]

--- a/release_tester/license_manager_tests/helpers/license_helper.py
+++ b/release_tester/license_manager_tests/helpers/license_helper.py
@@ -19,6 +19,7 @@ DEFAULT_CLIENT_ID = "my-client-id"
 DEFAULT_CLIENT_SECRET = "111aaa22-333b-4ccc-d5dd-e678ffff9012"
 CLIENT_ID = os.environ.get("CLIENT_ID", DEFAULT_CLIENT_ID)
 CLIENT_SECRET = os.environ.get("CLIENT_SECRET", DEFAULT_CLIENT_SECRET)
+MAX_ACTIVE_DEPLOYMENTS = "512"
 
 INVENTORY_FILE_NAME = "inventory.json"
 LICENSE_FILE_NAME = "license_key.txt"
@@ -92,7 +93,7 @@ class LicenseHelper:
         """activate deployment with operator platform tool"""
         # activate deployment
         command = f'{self.tool_path} license activate --arango.endpoint="{self._get_base_url()}" --arango.authentication Token --arango.token "{self._get_jwt_token()}" --license.client.id "{client_id}" --license.client.secret "{client_secret}"'
-        LicenseHelper.run_command(command)
+        return LicenseHelper.run_command(command).stderr.strip()
 
     @step
     def apply_license(self):
@@ -125,7 +126,3 @@ class LicenseHelper:
             os.remove(inventory_path)
         if Path(license_key_path).exists():
             os.remove(license_key_path)
-        # deleting operator platform tool after each test suite execution is suboptimal
-        # tool_path = f"{lm_tests_dir_path}/{TOOL_NAME}"
-        # if Path(tool_path).exists():
-        #     os.remove(tool_path)

--- a/release_tester/license_manager_tests/leader_follower_managed_license.py
+++ b/release_tester/license_manager_tests/leader_follower_managed_license.py
@@ -25,7 +25,7 @@ class ManagedLicenseLeaderFollowerTestSuite(LicenseManagerLeaderFollowerBaseTest
     @run_before_each_testcase
     @step
     def setup_leader_follower(self):
-        """recreate a leader-follower deployment if needed and instantiate LicenseHelper"""
+        """instantiate LicenseHelper and recreate leader follower deployment if needed"""
         if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
             self.recreate_deployment()
         self.first_test = False

--- a/release_tester/license_manager_tests/leader_follower_managed_license.py
+++ b/release_tester/license_manager_tests/leader_follower_managed_license.py
@@ -6,7 +6,12 @@ from license_manager_tests.base.managed_license_base import ManagedLicenseBaseTe
 from reporting.reporting_utils import step
 from test_suites_core.base_test_suite import testcase, run_before_each_testcase, disable
 from test_suites_core.cli_test_suite import CliTestSuiteParameters
-from license_manager_tests.helpers.license_helper import LicenseHelper, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET
+from license_manager_tests.helpers.license_helper import (
+    LicenseHelper,
+    DEFAULT_CLIENT_ID,
+    DEFAULT_CLIENT_SECRET,
+    MAX_ACTIVE_DEPLOYMENTS,
+)
 
 
 class ManagedLicenseLeaderFollowerTestSuite(LicenseManagerLeaderFollowerBaseTestSuite, ManagedLicenseBaseTestSuite):
@@ -15,11 +20,15 @@ class ManagedLicenseLeaderFollowerTestSuite(LicenseManagerLeaderFollowerBaseTest
     def __init__(self, params: CliTestSuiteParameters):
         super().__init__(params)
         self.suite_name = "Managed license test suite: Clean install"
+        self.first_test = True
 
     @run_before_each_testcase
     @step
     def setup_leader_follower(self):
-        """instantiate LicenseHelper"""
+        """recreate a leader-follower deployment if needed and instantiate LicenseHelper"""
+        if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
+            self.recreate_deployment()
+        self.first_test = False
         self.lh = LicenseHelper(self.starter, self.lm_tests_dir)
 
     @testcase("1. Attempt to generate a license key with incorrect client id and secret key - Leader follower")
@@ -38,30 +47,34 @@ class ManagedLicenseLeaderFollowerTestSuite(LicenseManagerLeaderFollowerBaseTest
     def test_negative_activate_deployment(self):
         """attempt to activate a deployment with incorrect client id and secret key"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment(client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET)
+            command_output = self.lh.activate_deployment(
+                client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET
+            )
         result = self.lh.get_license_data()["json"]
+        assert all([s in command_output for s in ["Error", "401", "unauthorized"]])
         assert not {"license", "grant"}.issubset(result.keys())
         assert "diskUsage" in result
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("3. Generate a license key with operator platform tool and apply the license - Leader follower")
     def test_generate_and_apply_license(self):
         """generate a new license key with operator platform tool and apply the license"""
         with step("generate a new license key with operator platform tool"):
             self.lh.generate_license_key()
-        self.lh.apply_license()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+        license_key_file_content = self.lh.get_license_key_file_content()
+        if not MAX_ACTIVE_DEPLOYMENTS in license_key_file_content:  # skip verifications if deployments limit is reached
+            self.lh.apply_license()
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("4. Use operator platform tool to activate deployment - Leader follower")
     def test_activate_deployment(self):
         """use operator platform tool to activate deployment"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+            command_output = self.lh.activate_deployment()
+        if not MAX_ACTIVE_DEPLOYMENTS in command_output:  # skip verifications if deployments limit is reached
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]

--- a/release_tester/license_manager_tests/single_server_managed_license.py
+++ b/release_tester/license_manager_tests/single_server_managed_license.py
@@ -6,7 +6,12 @@ from license_manager_tests.base.managed_license_base import ManagedLicenseBaseTe
 from reporting.reporting_utils import step
 from test_suites_core.base_test_suite import testcase, run_before_each_testcase, disable
 from test_suites_core.cli_test_suite import CliTestSuiteParameters
-from license_manager_tests.helpers.license_helper import LicenseHelper, DEFAULT_CLIENT_ID, DEFAULT_CLIENT_SECRET
+from license_manager_tests.helpers.license_helper import (
+    LicenseHelper,
+    DEFAULT_CLIENT_ID,
+    DEFAULT_CLIENT_SECRET,
+    MAX_ACTIVE_DEPLOYMENTS,
+)
 
 
 class ManagedLicenseSingleServerTestSuite(LicenseManagerSingleServerBaseTestSuite, ManagedLicenseBaseTestSuite):
@@ -15,11 +20,15 @@ class ManagedLicenseSingleServerTestSuite(LicenseManagerSingleServerBaseTestSuit
     def __init__(self, params: CliTestSuiteParameters):
         super().__init__(params)
         self.suite_name = "Managed license test suite: Clean install"
+        self.first_test = True
 
     @run_before_each_testcase
     @step
     def setup_single_server(self):
-        """instantiate LicenseHelper"""
+        """instantiate LicenseHelper and recreate deployment if needed"""
+        if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
+            self.recreate_deployment()
+        self.first_test = False
         self.lh = LicenseHelper(self.starter, self.lm_tests_dir)
 
     @testcase("1. Attempt to generate a license key with incorrect client id and secret key - Single server")
@@ -38,30 +47,34 @@ class ManagedLicenseSingleServerTestSuite(LicenseManagerSingleServerBaseTestSuit
     def test_negative_activate_deployment(self):
         """attempt to activate a deployment with incorrect client id and secret key"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment(client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET)
+            command_output = self.lh.activate_deployment(
+                client_id=DEFAULT_CLIENT_ID, client_secret=DEFAULT_CLIENT_SECRET
+            )
         result = self.lh.get_license_data()["json"]
+        assert all([s in command_output for s in ["Error", "401", "unauthorized"]])
         assert not {"license", "grant"}.issubset(result.keys())
         assert "diskUsage" in result
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("3. Generate a license key with operator platform tool and apply the license - Single server")
     def test_generate_and_apply_license(self):
         """generate a new license key with operator platform tool and apply the license"""
         with step("generate a new license key with operator platform tool"):
             self.lh.generate_license_key()
-        self.lh.apply_license()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+        license_key_file_content = self.lh.get_license_key_file_content()
+        if not MAX_ACTIVE_DEPLOYMENTS in license_key_file_content:  # skip verifications if deployments limit is reached
+            self.lh.apply_license()
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]
 
-    @disable("re-enable when number of active deployments is reset")
     @testcase("4. Use operator platform tool to activate deployment - Single server")
     def test_activate_deployment(self):
         """use operator platform tool to activate deployment"""
         with step("use operator platform tool to activate deployment"):
-            self.lh.activate_deployment()
-        result = self.lh.get_license_data()["json"]
-        assert "license" in result
-        assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
-        assert result["grant"]["managed"]
+            command_output = self.lh.activate_deployment()
+        if not MAX_ACTIVE_DEPLOYMENTS in command_output:  # skip verifications if deployments limit is reached
+            result = self.lh.get_license_data()["json"]
+            assert "license" in result
+            assert {"licenseId", "deploymentId"}.issubset(result["grant"].keys())
+            assert result["grant"]["managed"]

--- a/release_tester/license_manager_tests/single_server_managed_license.py
+++ b/release_tester/license_manager_tests/single_server_managed_license.py
@@ -25,7 +25,7 @@ class ManagedLicenseSingleServerTestSuite(LicenseManagerSingleServerBaseTestSuit
     @run_before_each_testcase
     @step
     def setup_single_server(self):
-        """instantiate LicenseHelper and recreate deployment if needed"""
+        """instantiate LicenseHelper and recreate single server deployment if needed"""
         if not self.first_test:  # we only want to recreate a deployment for 2nd and subsequent tests
             self.recreate_deployment()
         self.first_test = False

--- a/release_tester/test_suites_core/base_test_suite.py
+++ b/release_tester/test_suites_core/base_test_suite.py
@@ -189,15 +189,15 @@ class BaseTestSuite(metaclass=MetaTestSuite):
         return len(self.get_own_testcases()) > 0
 
     def get_run_before_suite_methods(self):
-        """list methods that are marked to be ran before test suite"""
+        """list methods that are marked to be run before test suite"""
         return [getattr(self, attr) for attr in dir(self) if hasattr(getattr(self, attr), "run_before_suite")]
 
     def get_run_after_suite_methods(self):
-        """list methods that are marked to be ran before test suite"""
+        """list methods that are marked to be run before test suite"""
         return [getattr(self, attr) for attr in dir(self) if hasattr(getattr(self, attr), "run_after_suite")]
 
     def get_run_before_each_testcase_methods(self):
-        """list methods that are marked to be ran before test suite"""
+        """list methods that are marked to be run before test suite"""
         return [getattr(self, attr) for attr in dir(self) if hasattr(getattr(self, attr), "run_before_each_testcase")]
 
     def get_run_after_each_testcase_methods(self):


### PR DESCRIPTION
This PR adds/changes the following:

* Re-enables positive managed license tests with active deployments number check (further actions and assertions in test will be skipped if key generation/deployment activation results in an error saying that limit of 512 deployments is reached). 
* Re-enables deployment recreation in the `before_test` hook 
* Disables an 'on_test_failure' hook as it conflicts with other before/after test/suite logic
* Minor typos/spelling corrections

<img width="1314" height="686" alt="Screenshot 2026-05-18 at 13 01 02" src="https://github.com/user-attachments/assets/dd276c48-2af3-4c4d-97b7-2f97d398218c" />

 