### PR TITLE
Explicitly set max number of open files for docker container

### DIFF
--- a/jenkins/common/setup_docker.sh
+++ b/jenkins/common/setup_docker.sh
@@ -33,6 +33,7 @@ DOCKER_ARGS=(
          --network="${DOCKER_NETWORK_NAME}" \
          --name="${DOCKER_NAME}" \
          --ulimit core=-1 \
+         --ulimit nofile=65536:65536 \
 # containerd         --rm \
          -v "$(pwd):/home/release-test-automation" \
          -v "$(pwd)/test_dir:/home/test_dir" \


### PR DESCRIPTION
Attempt to explicitly set the max number of open files in setup_docker.sh shell script. 